### PR TITLE
B3 propagation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  ruby: circleci/ruby@1.0.2
+  ruby: circleci/ruby@1.1.4
 
 docker_sbt: &docker_sbt
   docker:

--- a/natchez-extras-datadog/src/main/scala/com/ovoenergy/natchez/extras/datadog/DatadogTags.scala
+++ b/natchez-extras-datadog/src/main/scala/com/ovoenergy/natchez/extras/datadog/DatadogTags.scala
@@ -12,11 +12,8 @@ object DatadogTags {
 
   object SpanType {
     case object Custom extends SpanType
-
     case object Cache extends SpanType
-
     case object Web extends SpanType
-
     case object Db extends SpanType
   }
 

--- a/natchez-extras-datadog/src/main/scala/com/ovoenergy/natchez/extras/datadog/SubmittableSpan.scala
+++ b/natchez-extras-datadog/src/main/scala/com/ovoenergy/natchez/extras/datadog/SubmittableSpan.scala
@@ -4,7 +4,7 @@ import cats.Applicative
 import cats.effect.Clock
 import cats.effect.kernel.Resource.ExitCase
 import cats.syntax.apply._
-import com.ovoenergy.natchez.extras.datadog.DatadogTags.{SpanType, forThrowable}
+import com.ovoenergy.natchez.extras.datadog.DatadogTags.{forThrowable, SpanType}
 import com.ovoenergy.natchez.extras.datadog.data.UnsignedLong
 import io.circe.Encoder.encodeString
 import io.circe.generic.extras.Configuration
@@ -56,7 +56,7 @@ object SubmittableSpan {
    * means the Datadog Agent should always keep all our traces.
    */
   private val spanMetrics: Map[String, Double] =
-    Map("__sampling_priority_v1" -> 2.0d)
+    Map("_sampling_priority_v1" -> 2.0d)
 
   /**
    * Datadog docs: "Set this [error] value to 1 to indicate if an error occurred"
@@ -130,7 +130,7 @@ object SubmittableSpan {
           parentId = ids.parentId,
           error = isError(exitCase),
           `type` = inferSpanType(meta),
-          metrics = spanMetrics,
+          metrics = ids.parentId.fold(spanMetrics)(_ => Map.empty),
           meta = transformTags(meta, exitCase, ids.traceToken)
         )
     }

--- a/natchez-extras-datadog/src/main/scala/com/ovoenergy/natchez/extras/datadog/SubmittableSpan.scala
+++ b/natchez-extras-datadog/src/main/scala/com/ovoenergy/natchez/extras/datadog/SubmittableSpan.scala
@@ -4,7 +4,8 @@ import cats.Applicative
 import cats.effect.Clock
 import cats.effect.kernel.Resource.ExitCase
 import cats.syntax.apply._
-import com.ovoenergy.natchez.extras.datadog.DatadogTags.{forThrowable, SpanType}
+import com.ovoenergy.natchez.extras.datadog.DatadogTags.{SpanType, forThrowable}
+import com.ovoenergy.natchez.extras.datadog.data.UnsignedLong
 import io.circe.Encoder.encodeString
 import io.circe.generic.extras.Configuration
 import io.circe.generic.extras.semiauto._
@@ -18,15 +19,15 @@ import natchez.TraceValue.StringValue
  * with tags, hence this being its own file now
  */
 case class SubmittableSpan(
-  traceId: Long,
-  spanId: Long,
+  traceId: UnsignedLong,
+  spanId: UnsignedLong,
   name: String,
   service: String,
   resource: String,
   `type`: Option[SpanType],
   start: Long,
   duration: Long,
-  parentId: Option[Long],
+  parentId: Option[UnsignedLong],
   error: Option[Int],
   meta: Map[String, String],
   metrics: Map[String, Double]

--- a/natchez-extras-datadog/src/main/scala/com/ovoenergy/natchez/extras/datadog/data/UnsignedLong.scala
+++ b/natchez-extras-datadog/src/main/scala/com/ovoenergy/natchez/extras/datadog/data/UnsignedLong.scala
@@ -1,0 +1,32 @@
+package com.ovoenergy.natchez.extras.datadog.data
+
+import cats.effect.kernel.Sync
+import cats.syntax.either._
+import io.circe.{Decoder, Encoder}
+
+import java.lang.Long.{parseUnsignedLong, toUnsignedString}
+import scala.util.Random
+
+/**
+ * Wrapper for unsigned longs to make dealing with them less error prone
+ */
+case class UnsignedLong(value: Long) extends AnyVal {
+  def toString(radix: Int): String = toUnsignedString(value, radix)
+}
+
+object UnsignedLong {
+
+  def random[F[_]: Sync]: F[UnsignedLong] =
+    Sync[F].delay(UnsignedLong(Random.nextLong()))
+
+  def fromString(string: String, radix: Int): Either[String, UnsignedLong] =
+    Either.catchNonFatal(parseUnsignedLong(string, radix)).bimap(_.getMessage, UnsignedLong.apply)
+
+  implicit val decoder: Decoder[UnsignedLong] =
+    Decoder.decodeString.emap(fromString(_, radix = 10))
+
+  implicit val encoder: Encoder[UnsignedLong] =
+    Encoder.encodeString.contramap(_.toString)
+}
+
+

--- a/natchez-extras-datadog/src/main/scala/com/ovoenergy/natchez/extras/datadog/data/UnsignedLong.scala
+++ b/natchez-extras-datadog/src/main/scala/com/ovoenergy/natchez/extras/datadog/data/UnsignedLong.scala
@@ -12,6 +12,7 @@ import scala.util.Random
  */
 case class UnsignedLong(value: Long) extends AnyVal {
   def toString(radix: Int): String = toUnsignedString(value, radix)
+  override def toString: String = toString(radix = 10)
 }
 
 object UnsignedLong {
@@ -26,7 +27,5 @@ object UnsignedLong {
     Decoder.decodeString.emap(fromString(_, radix = 10))
 
   implicit val encoder: Encoder[UnsignedLong] =
-    Encoder.encodeString.contramap(_.toString)
+    Encoder.encodeString.contramap(_.toString(radix = 10))
 }
-
-

--- a/natchez-extras-datadog/src/main/scala/com/ovoenergy/natchez/extras/datadog/headers/HeaderInstances.scala
+++ b/natchez-extras-datadog/src/main/scala/com/ovoenergy/natchez/extras/datadog/headers/HeaderInstances.scala
@@ -1,0 +1,60 @@
+package com.ovoenergy.natchez.extras.datadog.headers
+
+import cats.Invariant
+import cats.syntax.either._
+import com.ovoenergy.natchez.extras.datadog.data.UnsignedLong
+import org.http4s.Header.Single
+import org.http4s.{Header, ParseFailure}
+import org.typelevel.ci.CIString
+
+/**
+ * Some additional instances for HTTP4s headers
+ * to make it easier to decode the propagation headers we need
+ */
+object HeaderInstances {
+
+  type SingleHeader[A] = Header[A, Single]
+
+  /**
+   * Parse a header value from a string into an unsigned long,
+   * The radix allows both decimal and hex encoded longs to be parsed
+   */
+  def unsignedLong(headerName: CIString, radix: Int): SingleHeader[UnsignedLong] =
+    new SingleHeader[UnsignedLong] {
+      def name: CIString =
+        headerName
+      def value(a: UnsignedLong): String =
+        a.toString(radix)
+      def parse(headerValue: String): Either[ParseFailure, UnsignedLong] =
+        UnsignedLong.fromString(headerValue, radix).leftMap { _ =>
+          ParseFailure("", s"Failed to parse $headerName as unsigned long")
+        }
+    }
+
+  /**
+   * Allow the string representation of a header to be transformed
+   * prior to it being passed to / after being recieved from the underlying typed header
+   */
+  implicit class HeaderOps[A](header: SingleHeader[A]) {
+    def transform(f: String => String): SingleHeader[A] =
+      new SingleHeader[A] {
+        def name: CIString = header.name
+        def value(a: A): String = f(header.value(a))
+        def parse(headerValue: String): Either[ParseFailure, A] = header.parse(f(headerValue))
+      }
+  }
+
+  /**
+   * Make it easy to create a header of a specific newtype
+   * by mapping to and from the underlying header value
+   */
+  implicit val invariant: Invariant[SingleHeader] =
+    new Invariant[SingleHeader] {
+      def imap[A, B](fa: SingleHeader[A])(f: A => B)(g: B => A): SingleHeader[B] =
+        new SingleHeader[B] {
+          def name: CIString = fa.name
+          def value(a: B): String = fa.value(g(a))
+          def parse(headerValue: String): Either[ParseFailure, B] = fa.parse(headerValue).map(f)
+        }
+    }
+}

--- a/natchez-extras-datadog/src/main/scala/com/ovoenergy/natchez/extras/datadog/headers/TraceHeaders.scala
+++ b/natchez-extras-datadog/src/main/scala/com/ovoenergy/natchez/extras/datadog/headers/TraceHeaders.scala
@@ -1,0 +1,48 @@
+package com.ovoenergy.natchez.extras.datadog.headers
+
+import cats.syntax.invariant._
+import HeaderInstances._
+import com.ovoenergy.natchez.extras.datadog.data.UnsignedLong
+import org.typelevel.ci._
+
+/**
+ * Here we explicitly model each of the headers we use to propagate traces,
+ * just to make it clearer exactly what we expect format-wise
+ */
+object TraceHeaders {
+
+  case class `X-Span-Id`(value: UnsignedLong)
+
+  object `X-Span-Id` {
+    implicit val header: SingleHeader[`X-Span-Id`] =
+      unsignedLong(ci"X-Span-Id", radix = 10).imap(`X-Span-Id`.apply)(_.value)
+  }
+
+  case class `X-Trace-Id`(value: UnsignedLong)
+
+  object `X-Trace-Id` {
+    implicit val header: SingleHeader[`X-Trace-Id`] =
+      unsignedLong(ci"X-Trace-Id", radix = 10).imap(`X-Trace-Id`.apply)(_.value)
+  }
+
+  case class `X-Parent-Id`(value: UnsignedLong)
+
+  object `X-Parent-Id` {
+    implicit val header: SingleHeader[`X-Parent-Id`] =
+      unsignedLong(ci"X-Parent-Id", radix = 10).imap(`X-Parent-Id`.apply)(_.value)
+  }
+
+  case class `X-B3-Span-Id`(value: UnsignedLong)
+
+  object `X-B3-Span-Id` {
+    implicit val header: SingleHeader[`X-B3-Span-Id`] =
+      unsignedLong(ci"X-B3-Span-Id", radix = 16).imap(`X-B3-Span-Id`.apply)(_.value).transform(_.take(16))
+  }
+
+  case class `X-B3-Trace-Id`(value: UnsignedLong)
+
+  object `X-B3-Trace-Id` {
+    implicit val header: SingleHeader[`X-B3-Trace-Id`] =
+      unsignedLong(ci"X-B3-Trace-Id", radix = 16).imap(`X-B3-Trace-Id`.apply)(_.value).transform(_.take(16))
+  }
+}

--- a/natchez-extras-datadog/src/test/scala/com/ovoenergy/natchez/extras/datadog/SpanIdentifiersTest.scala
+++ b/natchez-extras-datadog/src/test/scala/com/ovoenergy/natchez/extras/datadog/SpanIdentifiersTest.scala
@@ -10,7 +10,12 @@ import org.scalatest.wordspec.AnyWordSpec
 import org.scalatest.{EitherValues, OptionValues}
 import org.scalatestplus.scalacheck.Checkers
 
-class SpanIdentifiersTest extends AnyWordSpec with Matchers with Checkers with OptionValues with EitherValues {
+class SpanIdentifiersTest
+    extends AnyWordSpec
+    with Matchers
+    with Checkers
+    with OptionValues
+    with EitherValues {
 
   "Span identifiers" should {
 

--- a/natchez-extras-datadog/src/test/scala/com/ovoenergy/natchez/extras/datadog/SpanIdentifiersTest.scala
+++ b/natchez-extras-datadog/src/test/scala/com/ovoenergy/natchez/extras/datadog/SpanIdentifiersTest.scala
@@ -3,12 +3,14 @@ package com.ovoenergy.natchez.extras.datadog
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global
 import com.ovoenergy.natchez.extras.datadog.SpanIdentifiers._
+import com.ovoenergy.natchez.extras.datadog.data.UnsignedLong
 import natchez.Kernel
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.{EitherValues, OptionValues}
 import org.scalatestplus.scalacheck.Checkers
 
-class SpanIdentifiersTest extends AnyWordSpec with Matchers with Checkers {
+class SpanIdentifiersTest extends AnyWordSpec with Matchers with Checkers with OptionValues with EitherValues {
 
   "Span identifiers" should {
 
@@ -48,5 +50,23 @@ class SpanIdentifiersTest extends AnyWordSpec with Matchers with Checkers {
 
   "Ignore header case when extracting info" in {
     fromKernel[IO](Kernel(Map("x-TRACe-tokeN" -> "foo"))).unsafeRunSync().traceToken shouldBe "foo"
+  }
+
+  "Output hex-encoded B3 Trace IDs alongside decimal encoded Datadog IDs" in {
+    val result = SpanIdentifiers.create[IO].map(SpanIdentifiers.toKernel).unsafeRunSync()
+    val ddSpanId: String = result.toHeaders.get("X-Trace-Id").value
+    val b3SpanId: String = result.toHeaders.get("X-B3-Trace-Id").value
+    val ddULong = UnsignedLong.fromString(ddSpanId, 10)
+    val b3ULong = UnsignedLong.fromString(b3SpanId, 16)
+    ddULong shouldBe b3ULong
+  }
+
+  "Output hex-encoded B3 Span IDs alongside decimal encoded Datadog Parent IDs" in {
+    val result = SpanIdentifiers.create[IO].map(SpanIdentifiers.toKernel).unsafeRunSync()
+    val ddSpanId: String = result.toHeaders.get("X-Parent-Id").value
+    val b3SpanId: String = result.toHeaders.get("X-B3-Span-Id").value
+    val ddULong = UnsignedLong.fromString(ddSpanId, 10)
+    val b3ULong = UnsignedLong.fromString(b3SpanId, 16)
+    ddULong shouldBe b3ULong
   }
 }

--- a/natchez-extras-datadog/src/test/scala/com/ovoenergy/natchez/extras/datadog/data/UnsignedLongTest.scala
+++ b/natchez-extras-datadog/src/test/scala/com/ovoenergy/natchez/extras/datadog/data/UnsignedLongTest.scala
@@ -1,12 +1,26 @@
 package com.ovoenergy.natchez.extras.datadog.data
 
-import com.ovoenergy.natchez.extras.datadog.data.UnsignedLong.fromString
+import com.ovoenergy.natchez.extras.datadog.data.UnsignedLong._
+import org.scalatest.EitherValues
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+import io.circe.syntax._
 
-class UnsignedLongTest extends AnyWordSpec with Matchers {
+class UnsignedLongTest extends AnyWordSpec with Matchers with EitherValues {
 
   "Unsigned long" should {
+
+    val maxValue: UnsignedLong =
+      fromString("18446744073709551615", 10).value
+
+    "Encode JSON values" in {
+      encoder(maxValue).toString shouldBe "18446744073709551615"
+    }
+
+    "Decode JSON values" in {
+      val jsonValue = BigInt("18446744073709551615").asJson
+      decoder.decodeJson(jsonValue) shouldBe Right(maxValue)
+    }
 
     "Decode and Encode decimal-encoded unsigned long values" in {
       fromString("18446744073709551615", 10).map(_.toString(10)) shouldBe Right("18446744073709551615")

--- a/natchez-extras-datadog/src/test/scala/com/ovoenergy/natchez/extras/datadog/data/UnsignedLongTest.scala
+++ b/natchez-extras-datadog/src/test/scala/com/ovoenergy/natchez/extras/datadog/data/UnsignedLongTest.scala
@@ -1,0 +1,27 @@
+package com.ovoenergy.natchez.extras.datadog.data
+
+import com.ovoenergy.natchez.extras.datadog.data.UnsignedLong.fromString
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class UnsignedLongTest extends AnyWordSpec with Matchers {
+
+  "Unsigned long" should {
+
+    "Decode and Encode decimal-encoded unsigned long values" in {
+      fromString("18446744073709551615", 10).map(_.toString(10)) shouldBe Right("18446744073709551615")
+    }
+
+    "Fail if the long value is out of range" in {
+      fromString("18446744073709551616", 10).isLeft shouldBe true
+    }
+
+    "Decode and Encode 64 bit hex-encoded unsigned long values" in {
+      fromString("a2fb4a1d1a96d312", 16).map(_.toString(16)) shouldBe Right("a2fb4a1d1a96d312")
+    }
+
+    "Fail if provided a value over 64 bits in length" in {
+      fromString("463ac35c9f6413ad48485a3953bb6124", 16).map(_.toString(16)).isLeft shouldBe true
+    }
+  }
+}

--- a/natchez-extras-datadog/src/test/scala/com/ovoenergy/natchez/extras/datadog/headers/TraceHeadersTest.scala
+++ b/natchez-extras-datadog/src/test/scala/com/ovoenergy/natchez/extras/datadog/headers/TraceHeadersTest.scala
@@ -1,0 +1,19 @@
+package com.ovoenergy.natchez.extras.datadog.headers
+
+import com.ovoenergy.natchez.extras.datadog.headers.TraceHeaders.{`X-B3-Span-Id`, `X-B3-Trace-Id`}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class TraceHeadersTest extends AnyWordSpec with Matchers {
+
+  "Trace headers" should {
+
+    "Truncate B3 trace & span headers to their first 64 bits" in {
+      val longTraceId: String = "463ac35c9f6413ad48485a3953bb6124"
+      val traceId = `X-B3-Trace-Id`.header.parse(longTraceId).map(`X-B3-Trace-Id`.header.value)
+      val spanId = `X-B3-Span-Id`.header.parse(longTraceId).map(`X-B3-Span-Id`.header.value)
+      traceId shouldBe Right(longTraceId.take(16))
+      spanId shouldBe Right(longTraceId.take(16))
+    }
+  }
+}


### PR DESCRIPTION
This PR adds support for propagating traces through B3 headers detailed [in this doc](https://github.com/openzipkin/b3-propagation)

It also makes the handling of trace IDs a bit more robust & fixes some bugs with how they were handled previously by introducing an `UnsignedLong` wrapper that ensures we treat trace IDs as being unsigned and serialise them properly. The old code, for example, called `abs` on a random `long` when generating the trace IDs which means it would've only used half of the possible values of the long.

I've also fixed an issue with the `_sampling_priority_v1` metric we send to force Datadog to keep all traces - there was an extra leading underscore and it only needs to be attached to the root span.