### PR TITLE
Record submitted tags in TestEntryPoint

### DIFF
--- a/docs/docs/docs/natchez-datadog.md
+++ b/docs/docs/docs/natchez-datadog.md
@@ -13,8 +13,8 @@ Once you've got the `EntryPoint` you can then use Natchez as described in [its R
 Depending on how you're using the Datadog agent you may need to set some configuration values
 to enable the APM. Details can be found [on the Datadog website](https://docs.datadoghq.com/tracing/send_traces/)
 
-`natchez-extras-datadog` currently expects the agent to be reachable over HTTP at `http://localhost:8126` - if you're running the 
-agent in a docker container this should typically be the case.
+By default `natchez-extras-datadog` currently expects the agent to be reachable over HTTP at `http://localhost:8126`. 
+You can choose a different URL by setting the `agentHost` parameter when constructing the `EntryPoint`.
 
 ## Installation
 

--- a/natchez-extras-http4s/src/test/scala/com/ovoenergy/natchez/extras/http4s/client/TracedClientTest.scala
+++ b/natchez-extras-http4s/src/test/scala/com/ovoenergy/natchez/extras/http4s/client/TracedClientTest.scala
@@ -5,7 +5,7 @@ import cats.effect.IO
 import cats.effect.unsafe.implicits.global
 import com.ovoenergy.natchez.extras.http4s.Configuration
 import com.ovoenergy.natchez.extras.testkit.TestEntryPoint
-import com.ovoenergy.natchez.extras.testkit.TestEntryPoint.TestSpan
+import com.ovoenergy.natchez.extras.testkit.TestEntryPoint.SubmittedSpan
 import natchez.{Kernel, Span}
 import org.http4s.{Header, Request}
 import org.scalatest.Inspectors
@@ -41,7 +41,7 @@ class TracedClientTest extends AnyWordSpec with Matchers {
 
     "Create a new span for HTTP requests" in {
 
-      val spans: List[TestSpan] = (
+      val spans: List[SubmittedSpan] = (
         for {
           client <- TestClient[IO]
           ep     <- TestEntryPoint[IO]

--- a/natchez-extras-http4s/src/test/scala/com/ovoenergy/natchez/extras/http4s/client/TracedClientTest.scala
+++ b/natchez-extras-http4s/src/test/scala/com/ovoenergy/natchez/extras/http4s/client/TracedClientTest.scala
@@ -5,7 +5,7 @@ import cats.effect.IO
 import cats.effect.unsafe.implicits.global
 import com.ovoenergy.natchez.extras.http4s.Configuration
 import com.ovoenergy.natchez.extras.testkit.TestEntryPoint
-import com.ovoenergy.natchez.extras.testkit.TestEntryPoint.SubmittedSpan
+import com.ovoenergy.natchez.extras.testkit.TestEntryPoint.CompletedSpan
 import natchez.{Kernel, Span}
 import org.http4s.{Header, Request}
 import org.scalatest.Inspectors
@@ -41,7 +41,7 @@ class TracedClientTest extends AnyWordSpec with Matchers {
 
     "Create a new span for HTTP requests" in {
 
-      val spans: List[SubmittedSpan] = (
+      val spans: List[CompletedSpan] = (
         for {
           client <- TestClient[IO]
           ep     <- TestEntryPoint[IO]

--- a/natchez-extras-testkit/src/main/scala/com/ovoenergy/natchez/extras/testkit/TestEntryPoint.scala
+++ b/natchez-extras-testkit/src/main/scala/com/ovoenergy/natchez/extras/testkit/TestEntryPoint.scala
@@ -40,7 +40,7 @@ object TestEntryPoint {
           Ref.of[F, List[(String, TraceValue)]](List.empty).map { ref =>
             new TestSpan[F] {
               def tags: F[List[(String, TraceValue)]] = ref.get
-              def span(name: String): Resource[F, Span[F]] = makeSpan(name, Some(name), kern)
+              def span(newName: String): Resource[F, Span[F]] = makeSpan(newName, Some(name), kern)
               def put(fields: (String, TraceValue)*): F[Unit] = ref.update(_ ++ fields)
               def traceId: F[Option[String]] = F.pure(None)
               def spanId: F[Option[String]] = F.pure(None)

--- a/natchez-extras-testkit/src/main/scala/com/ovoenergy/natchez/extras/testkit/TestEntryPoint.scala
+++ b/natchez-extras-testkit/src/main/scala/com/ovoenergy/natchez/extras/testkit/TestEntryPoint.scala
@@ -4,7 +4,7 @@ import cats.effect.kernel.Resource.ExitCase
 import cats.effect.{Clock, Ref, Resource, Sync}
 import cats.syntax.flatMap._
 import cats.syntax.functor._
-import com.ovoenergy.natchez.extras.testkit.TestEntryPoint.SubmittedSpan
+import com.ovoenergy.natchez.extras.testkit.TestEntryPoint.CompletedSpan
 import natchez.{EntryPoint, Kernel, Span, TraceValue}
 
 import java.net.URI
@@ -15,12 +15,12 @@ import java.time.Instant
  * and additionally lets you see all the completed spans
  */
 trait TestEntryPoint[F[_]] extends EntryPoint[F] {
-  def spans: F[List[SubmittedSpan]]
+  def spans: F[List[CompletedSpan]]
 }
 
 object TestEntryPoint {
 
-  case class SubmittedSpan(
+  case class CompletedSpan(
     tags: List[(String, TraceValue)],
     parent: Option[String],
     completed: Instant,
@@ -34,7 +34,7 @@ object TestEntryPoint {
   }
 
   def apply[F[_]](implicit F: Sync[F]): F[TestEntryPoint[F]] =
-    Ref.of[F, List[SubmittedSpan]](List.empty).map { submitted =>
+    Ref.of[F, List[CompletedSpan]](List.empty).map { submitted =>
       def makeSpan(name: String, parent: Option[String], kern: Kernel): Resource[F, Span[F]] =
         Resource.makeCase(
           Ref.of[F, List[(String, TraceValue)]](List.empty).map { ref =>
@@ -52,13 +52,13 @@ object TestEntryPoint {
           for {
             tags <- span.tags
             time <- Clock[F].realTimeInstant
-            testSpan = SubmittedSpan(tags, parent, time, ec, kern, name)
+            testSpan = CompletedSpan(tags, parent, time, ec, kern, name)
             _ <- submitted.update(_ :+ testSpan)
           } yield ()
         }
 
       new TestEntryPoint[F] {
-        def spans: F[List[SubmittedSpan]] = submitted.get
+        def spans: F[List[CompletedSpan]] = submitted.get
         def root(name: String): Resource[F, Span[F]] = makeSpan(name, None, Kernel(Map.empty))
         def continue(name: String, k: Kernel): Resource[F, Span[F]] = makeSpan(name, None, k)
         def continueOrElseRoot(name: String, k: Kernel): Resource[F, Span[F]] = makeSpan(name, None, k)

--- a/natchez-extras-testkit/src/test/scala/com/ovoenergy/natchez/extras/testkit/TestEntryPointTest.scala
+++ b/natchez-extras-testkit/src/test/scala/com/ovoenergy/natchez/extras/testkit/TestEntryPointTest.scala
@@ -1,0 +1,34 @@
+package com.ovoenergy.natchez.extras.testkit
+
+import cats.effect.IO
+import cats.effect.unsafe.implicits._
+import natchez.{Kernel, TraceValue}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class TestEntryPointTest extends AnyWordSpec with Matchers {
+
+  val testKernel: Kernel =
+    Kernel(Map("test" -> "header"))
+
+  "TestEntryPoint" should {
+
+    "Capture tags sent along with each span" in {
+      TestEntryPoint[IO]
+        .flatMap { ep =>
+          ep.continue("root-span", testKernel).use { root =>
+            root.put("tag" -> "root-span") >> root.span("sub-span").use { span =>
+              span.put("tag" -> "sub-span")
+            }
+          } >> ep.spans
+        }
+        .map { results =>
+          results.map(s => s.name -> s.tags) shouldBe List(
+            "sub-span" -> List("tag" -> ("sub-span": TraceValue)),
+            "root-span" -> List("tag" -> ("root-span": TraceValue))
+          )
+        }
+        .unsafeRunSync()
+    }
+  }
+}


### PR DESCRIPTION
This fixes a long standing annoyance with `TestEntryPoint` which was that it didn't keep track of any tags submitted to the spans it created. Now it does so tests can be written that ensure applications are sending the right tags along to Natchez.

I renamed `TestSpan` to `CompletedSpan` to make it clearer that spans are only available for inspection by tests after they've been completed and I inlined the creation of spans & resource handling because the two separate functions confused me at first.