### PR TITLE
Add metrics gauge and distribution

### DIFF
--- a/docs/docs/docs/metrics.md
+++ b/docs/docs/docs/metrics.md
@@ -6,8 +6,14 @@ permalink: docs/
 
 # Datadog Metrics
 
-This module provides a `Metrics[F] with Events[F]` trait that lets you send counters, histograms and events to the [Datadog agent](https://docs.datadoghq.com/agent/) over UDP.
+This module provides a `Metrics[F] with Events[F]` trait that lets you send metrics as well as events to the [Datadog agent](https://docs.datadoghq.com/agent/) over UDP.
 Note that this means you are unlikely to receive errors if the Datadog agent isn't reachable!
+
+The following metric types are supported:
+- counter
+- histogram
+- gauge
+- distribution
 
 For more details about counters, histograms & the UDP format see the Datadog [DogStatsD documentation](https://docs.datadoghq.com/developers/dogstatsd/?tab=hostagent).
 For more details about events see the [event documentation.](https://docs.datadoghq.com/events/)
@@ -56,16 +62,24 @@ object MetricApp extends IOApp {
 
   val exampleCounter: Metric =
     Metric(name = "my_counter", tags = Map.empty)
-
+    
   val exampleHistogram: Metric =
     Metric(name = "my_histogram", tags = Map.empty)
-
+    
+  val exampleGauge: Metric =
+    Metric(name = "my_gauge", tags = Map.empty)
+    
+  val exampleGauge: Metric =
+    Metric(name = "my_gauge", tags = Map.empty)
+    
   def run(args: List[String]): IO[ExitCode] =
     Dogstatsd[IO](metricConfig).use { metrics: Metrics[IO] with Events[IO] =>
       for {
         _ <- metrics.counter(exampleCounter)(1)
         _ <- metrics.histogram(exampleHistogram)(1)
         _ <- metrics.event(exampleEvent)
+        _ <- metrics.gauge(exampleGauge)(1)
+        _ <- metrics.distribution(exampleGauge)(1)
       } yield ExitCode.Success
     }
 }

--- a/natchez-extras-metrics/src/main/scala/com/ovoenergy/natchez/extras/metrics/Metrics.scala
+++ b/natchez-extras-metrics/src/main/scala/com/ovoenergy/natchez/extras/metrics/Metrics.scala
@@ -11,6 +11,8 @@ import com.ovoenergy.natchez.extras.metrics.Metrics.Metric
 trait Metrics[F[_]] {
   def counter(metric: Metric)(value: Long): F[Unit]
   def histogram(metric: Metric)(value: Long): F[Unit]
+  def gauge(metric: Metric)(value: Long): F[Unit]
+  def distribution(metric: Metric)(value: Long): F[Unit]
 }
 
 object Metrics {
@@ -27,6 +29,10 @@ object Metrics {
         nt(metrics.counter(metric)(value))
       def histogram(metric: Metric)(value: Long): G[Unit] =
         nt(metrics.histogram(metric)(value))
+      def gauge(metric: Metric)(value: Long): G[Unit] =
+        nt(metrics.gauge(metric)(value))
+      def distribution(metric: Metric)(value: Long): G[Unit] =
+        nt(metrics.gauge(metric)(value))
     }
 
   /**
@@ -41,6 +47,14 @@ object Metrics {
         }
       def histogram(m: Metric)(value: Long): F[Unit] =
         (a.histogram(m)(value), b.histogram(m)(value)).mapN {
+          case ((), ()) => ()
+        }
+      override def gauge(m: Metric)(value: Long): F[Unit] =
+        (a.gauge(m)(value), b.gauge(m)(value)).mapN {
+          case ((), ()) => ()
+        }
+      override def distribution(m: Metric)(value: Long): F[Unit] =
+        (a.gauge(m)(value), b.gauge(m)(value)).mapN {
           case ((), ()) => ()
         }
     }


### PR DESCRIPTION
This PR adds support for `Metrics[F].gauge` and `Metrics[F].distribution`.