### PR TITLE
Move to MUnit

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -46,9 +46,10 @@ val common = Seq(
     compilerPlugin("org.typelevel" % "kind-projector" % "0.13.2" cross CrossVersion.full),
     "org.typelevel" %% "cats-core" % "2.6.1",
     "org.typelevel" %% "cats-effect" % "3.2.9",
-    "org.scalatest" %% "scalatest" % "3.2.10" % Test,
+    "org.scalameta" %% "munit" % "0.7.29" % Test,
     "org.scalacheck" %% "scalacheck" % "1.15.4" % Test,
-    "org.scalatestplus" %% "scalacheck-1-14" % "3.2.2.0" % Test
+    "org.typelevel" %% "munit-cats-effect-3" % "1.0.7" % Test,
+    "org.typelevel" %% "scalacheck-effect-munit" % "1.0.3" % Test
   )
 )
 
@@ -209,7 +210,6 @@ lazy val datadogMetrics = project
   .dependsOn(metricsCommon)
   .settings(
     libraryDependencies ++= Seq(
-      "org.typelevel" %% "claimant" % "0.2.0" % Test,
       "co.fs2" %% "fs2-core" % fs2Version,
       "co.fs2" %% "fs2-io" % fs2Version,
     )

--- a/natchez-extras-datadog/src/test/scala/com/ovoenergy/natchez/extras/datadog/DatadogTest.scala
+++ b/natchez-extras-datadog/src/test/scala/com/ovoenergy/natchez/extras/datadog/DatadogTest.scala
@@ -1,19 +1,16 @@
 package com.ovoenergy.natchez.extras.datadog
 
 import cats.effect._
-import cats.effect.unsafe.implicits._
 import cats.instances.list._
 import cats.syntax.traverse._
 import com.ovoenergy.natchez.extras.datadog.Datadog.entryPoint
 import com.ovoenergy.natchez.extras.datadog.DatadogTags.SpanType.{Cache, Db, Web}
 import com.ovoenergy.natchez.extras.datadog.DatadogTags.spanType
+import munit.CatsEffectSuite
 import natchez.EntryPoint
 import org.http4s.Request
 import org.http4s.circe.CirceEntityDecoder._
 import org.http4s.syntax.literals._
-import org.scalatest.{Inspectors, OptionValues}
-import org.scalatest.matchers.should.Matchers
-import org.scalatest.wordspec.AnyWordSpec
 
 import scala.concurrent.duration._
 
@@ -21,111 +18,129 @@ import scala.concurrent.duration._
  * This tests both the datadog span code itself and the submission of metrics over HTTP
  * Could be expanded but even just these tests exposed concurrency issues with my original code.
  */
-class DatadogTest extends AnyWordSpec with Matchers with OptionValues {
+class DatadogTest extends CatsEffectSuite {
 
   def run(f: EntryPoint[IO] => IO[Unit]): IO[List[Request[IO]]] =
     TestClient[IO].flatMap(c => entryPoint(c.client, "test", "blah").use(f) >> c.requests)
 
-  "Datadog span" should {
+  test("Obtain the agent host from the parameter") {
+    assertIO(
+      returns = List(uri"http://example.com/v0.3/traces"),
+      obtained = for {
+        client <- TestClient[IO]
+        ep = entryPoint(client.client, "a", "b", agentHost = uri"http://example.com")
+        _        <- ep.use(_.root("foo").use(_ => IO.unit))
+        requests <- client.requests
+      } yield requests.map(_.uri)
+    )
+  }
 
-    "Obtain the agent host from the parameter" in {
-      (
-        for {
-          client <- TestClient[IO]
-          ep = entryPoint(client.client, "a", "b", agentHost = uri"http://example.com")
-          _        <- ep.use(_.root("foo").use(_ => IO.unit))
-          requests <- client.requests
-        } yield requests.map(_.uri) shouldBe List(
-          uri"http://example.com/v0.3/traces"
-        )
-      ).unsafeRunSync()
+  test("Allow you to modify trace tokens") {
+    assertIO(
+      returns = Some("foo"),
+      obtained = for {
+        client <- TestClient[IO]
+        ep = entryPoint(client.client, "a", "b", agentHost = uri"http://example.com")
+        kernel <- ep.use(_.root("foo").use(s => s.put("traceToken" -> "foo") >> s.kernel))
+      } yield kernel.toHeaders.get("X-Trace-Token")
+    )
+  }
+
+  test("Continue to send HTTP calls even if one of them fails") {
+
+    val test: EntryPoint[IO] => IO[Unit] =
+      ep =>
+        ep.root("first").use(_ => IO.unit) >>
+        IO.sleep(1.second) >>
+        ep.root("second").use(_ => IO.unit)
+
+    assertIO(
+      returns = 2,
+      obtained = for {
+        client <- TestClient[IO]
+        _      <- client.respondWith(IO.raiseError(new Exception))
+        ep = entryPoint(client.client, "a", "b", agentHost = uri"http://example.com")
+        _        <- ep.use(test)
+        requests <- client.requests
+      } yield requests.length
+    )
+  }
+
+  test("Submit the right info to Datadog when closed") {
+    for {
+      res   <- run(_.root("bar:res").use(_.put("k" -> "v") >> IO.sleep(1.milli)))
+      spans <- res.flatTraverse(_.as[List[List[SubmittableSpan]]])
+    } yield {
+      val span = spans.flatten.head
+      assertEquals(span.name, "bar")
+      assertEquals(span.service, "test")
+      assertEquals(span.resource, "res")
+      assertEquals(span.`type`, None)
+      assertEquals(span.duration > 0, true)
+      assertEquals(span.meta.get("k"), Some("v"))
+      assertEquals(span.meta.contains("traceToken"), true)
     }
+  }
 
-    "Allow you to modify trace tokens" in {
-      (
-        for {
-          client <- TestClient[IO]
-          ep = entryPoint(client.client, "a", "b", agentHost = uri"http://example.com")
-          kernel <- ep.use(_.root("foo").use(s => s.put("traceToken" -> "foo") >> s.kernel))
-        } yield kernel.toHeaders.get("X-Trace-Token") shouldBe Some("foo")
-      ).unsafeRunSync()
+  test("Only include the sampling priority metric on the root span") {
+    for {
+      res   <- run(_.root("root").use(_.span("span").use(_ => IO.sleep(1.milli))))
+      spans <- res.flatTraverse(_.as[List[List[SubmittableSpan]]]).map(_.flatten)
+    } yield {
+      assertEquals(spans.find(_.parentId.isEmpty).map(_.metrics), Some(Map("_sampling_priority_v1" -> 2.0)))
+      assertEquals(spans.find(_.parentId.isDefined).map(_.metrics), Some(Map.empty[String, Double]))
     }
+  }
 
-    "Continue to send HTTP calls even if one of them fails" in {
-
-      val test: EntryPoint[IO] => IO[Unit] =
-        ep =>
-          ep.root("first").use(_ => IO.unit) >>
-          IO.sleep(1.second) >>
-          ep.root("second").use(_ => IO.unit)
-      (
-        for {
-          client <- TestClient[IO]
-          _      <- client.respondWith(IO.raiseError(new Exception))
-          ep = entryPoint(client.client, "a", "b", agentHost = uri"http://example.com")
-          _        <- ep.use(test)
-          requests <- client.requests
-        } yield requests.length shouldBe 2
-      ).unsafeRunSync()
+  test("Infer the right span.type from any tags set") {
+    List(Web, Cache, Db).traverse { typ =>
+      assertIO(
+        returns = Some(typ),
+        obtained = for {
+          res  <- run(_.root("bar:res").use(_.put(spanType(typ))))
+          span <- res.flatTraverse(_.as[List[List[SubmittableSpan]]])
+        } yield span.flatten.head.`type`
+      )
     }
+  }
 
-    "Submit the right info to Datadog when closed" in {
-
-      val res = run(_.root("bar:res").use(_.put("k" -> "v") >> IO.sleep(1.milli))).unsafeRunSync()
-      val span = res.flatTraverse(_.as[List[List[SubmittableSpan]]]).unsafeRunSync().flatten.head
-
-      span.name shouldBe "bar"
-      span.service shouldBe "test"
-      span.resource shouldBe "res"
-      span.`type` shouldBe None
-      span.duration > 0 shouldBe true
-      span.meta.get("k") shouldBe Some("v")
-      span.meta.contains("traceToken") shouldBe true
+  test("Submit multiple spans across multiple calls when span() is called") {
+    for {
+      res   <- run(_.root("bar").use(_.span("subspan").use(_ => IO.sleep(1.second))))
+      spans <- res.flatTraverse(_.as[List[List[SubmittableSpan]]]).map(_.flatten)
+    } yield {
+      assertEquals(spans.map(_.traceId).distinct.length, 1)
+      assertEquals(spans.map(_.spanId).distinct.length, 2)
     }
+  }
 
-    "Only include the sampling priority metric on the root span" in {
-      val res = run(_.root("root").use(_.span("span").use(_ => IO.sleep(1.milli)))).unsafeRunSync()
-      val spans = res.flatTraverse(_.as[List[List[SubmittableSpan]]]).unsafeRunSync().flatten
-      spans.find(_.parentId.isEmpty).value.metrics shouldBe Map("_sampling_priority_v1" -> 2.0)
-      spans.find(_.parentId.isDefined).value.metrics shouldBe Map.empty
+  test("Allow you to override the service name and resource with colons") {
+    for {
+      res   <- run(_.root("svc:name:res").use(_ => IO.unit))
+      spans <- res.flatTraverse(_.as[List[List[SubmittableSpan]]]).map(_.flatten)
+    } yield {
+      assertEquals(spans.head.resource, "res")
+      assertEquals(spans.head.service, "svc")
+      assertEquals(spans.head.name, "name")
     }
+  }
 
-    "Infer the right span.type from any tags set" in {
-      Inspectors.forAll(List(Web, Cache, Db)) { typ =>
-        val res = run(_.root("bar:res").use(_.put(spanType(typ)))).unsafeRunSync()
-        val span = res.flatTraverse(_.as[List[List[SubmittableSpan]]]).unsafeRunSync().flatten.head
-        span.`type` shouldBe Some(typ)
+  test("Inherit metadata into subspans but only at the time of creation") {
+    run(
+      _.root("bar:res").use { root =>
+        root.put("foo" -> "bar") >> root.span("sub").use(_.put("baz" -> "qux"))
       }
-    }
-
-    "Submit multiple spans across multiple calls when span() is called" in {
-      val res = run(_.root("bar").use(_.span("subspan").use(_ => IO.sleep(1.second)))).unsafeRunSync()
-      val spans = res.flatTraverse(_.as[List[List[SubmittableSpan]]]).unsafeRunSync().flatten
-      spans.map(_.traceId).distinct.length shouldBe 1
-      spans.map(_.spanId).distinct.length shouldBe 2
-    }
-
-    "Allow you to override the service name and resource with colons" in {
-      val res = run(_.root("svc:name:res").use(_ => IO.unit)).unsafeRunSync()
-      val spans = res.flatTraverse(_.as[List[List[SubmittableSpan]]]).unsafeRunSync().flatten
-      spans.head.resource shouldBe "res"
-      spans.head.service shouldBe "svc"
-      spans.head.name shouldBe "name"
-    }
-
-    "Inherit metadata into subspans but only at the time of creation" in {
-      val res = run(
-        _.root("bar:res").use { root =>
-          root.put("foo" -> "bar") >> root.span("sub").use(_.put("baz" -> "qux"))
-        }
-      ).unsafeRunSync()
-
-      val spans = res.flatTraverse(_.as[List[List[SubmittableSpan]]]).unsafeRunSync().flatten
+    ).flatMap(_.flatTraverse(_.as[List[List[SubmittableSpan]]]).map(_.flatten)).map { spans =>
       val rootSpan = spans.find(_.name == "bar").get
       val subSpan = spans.find(_.name == "sub").get
-
-      subSpan.meta.view.filterKeys(_ != "traceToken").toMap shouldBe Map("foo" -> "bar", "baz" -> "qux")
-      rootSpan.meta.view.filterKeys(_ != "traceToken").toMap shouldBe Map("foo" -> "bar")
+      assertEquals(
+        subSpan.meta.view.filterKeys(_ != "traceToken").toMap,
+        Map("foo" -> "bar", "baz" -> "qux")
+      )
+      assertEquals(
+        rootSpan.meta.view.filterKeys(_ != "traceToken").toMap,
+        Map("foo" -> "bar")
+      )
     }
   }
 }

--- a/natchez-extras-datadog/src/test/scala/com/ovoenergy/natchez/extras/datadog/data/UnsignedLongTest.scala
+++ b/natchez-extras-datadog/src/test/scala/com/ovoenergy/natchez/extras/datadog/data/UnsignedLongTest.scala
@@ -1,41 +1,36 @@
 package com.ovoenergy.natchez.extras.datadog.data
 
 import com.ovoenergy.natchez.extras.datadog.data.UnsignedLong._
-import org.scalatest.EitherValues
-import org.scalatest.matchers.should.Matchers
-import org.scalatest.wordspec.AnyWordSpec
 import io.circe.syntax._
+import munit.FunSuite
 
-class UnsignedLongTest extends AnyWordSpec with Matchers with EitherValues {
+class UnsignedLongTest extends FunSuite {
 
-  "Unsigned long" should {
+  val maxValue: UnsignedLong =
+    fromString("18446744073709551615", 10).toOption.get
 
-    val maxValue: UnsignedLong =
-      fromString("18446744073709551615", 10).value
+  test("Encode JSON values") {
+    assertEquals(encoder(maxValue).toString, "18446744073709551615")
+  }
 
-    "Encode JSON values" in {
-      encoder(maxValue).toString shouldBe "18446744073709551615"
-    }
+  test("Decode JSON values") {
+    val jsonValue = BigInt("18446744073709551615").asJson
+    assertEquals(decoder.decodeJson(jsonValue), Right(maxValue))
+  }
 
-    "Decode JSON values" in {
-      val jsonValue = BigInt("18446744073709551615").asJson
-      decoder.decodeJson(jsonValue) shouldBe Right(maxValue)
-    }
+  test("Decode and Encode decimal-encoded unsigned long values") {
+    assertEquals(fromString("18446744073709551615", 10).map(_.toString(10)), Right("18446744073709551615"))
+  }
 
-    "Decode and Encode decimal-encoded unsigned long values" in {
-      fromString("18446744073709551615", 10).map(_.toString(10)) shouldBe Right("18446744073709551615")
-    }
+  test("Fail if the long value is out of range") {
+    assert(fromString("18446744073709551616", 10).isLeft)
+  }
 
-    "Fail if the long value is out of range" in {
-      fromString("18446744073709551616", 10).isLeft shouldBe true
-    }
+  test("Decode and Encode 64 bit hex-encoded unsigned long values") {
+    assertEquals(fromString("a2fb4a1d1a96d312", 16).map(_.toString(16)), Right("a2fb4a1d1a96d312"))
+  }
 
-    "Decode and Encode 64 bit hex-encoded unsigned long values" in {
-      fromString("a2fb4a1d1a96d312", 16).map(_.toString(16)) shouldBe Right("a2fb4a1d1a96d312")
-    }
-
-    "Fail if provided a value over 64 bits in length" in {
-      fromString("463ac35c9f6413ad48485a3953bb6124", 16).map(_.toString(16)).isLeft shouldBe true
-    }
+  test("Fail if provided a value over 64 bits in length") {
+    assert(fromString("463ac35c9f6413ad48485a3953bb6124", 16).map(_.toString(16)).isLeft)
   }
 }

--- a/natchez-extras-datadog/src/test/scala/com/ovoenergy/natchez/extras/datadog/headers/TraceHeadersTest.scala
+++ b/natchez-extras-datadog/src/test/scala/com/ovoenergy/natchez/extras/datadog/headers/TraceHeadersTest.scala
@@ -1,19 +1,15 @@
 package com.ovoenergy.natchez.extras.datadog.headers
 
 import com.ovoenergy.natchez.extras.datadog.headers.TraceHeaders.{`X-B3-Span-Id`, `X-B3-Trace-Id`}
-import org.scalatest.matchers.should.Matchers
-import org.scalatest.wordspec.AnyWordSpec
+import munit.FunSuite
 
-class TraceHeadersTest extends AnyWordSpec with Matchers {
+class TraceHeadersTest extends FunSuite {
 
-  "Trace headers" should {
-
-    "Truncate B3 trace & span headers to their first 64 bits" in {
-      val longTraceId: String = "463ac35c9f6413ad48485a3953bb6124"
-      val traceId = `X-B3-Trace-Id`.header.parse(longTraceId).map(`X-B3-Trace-Id`.header.value)
-      val spanId = `X-B3-Span-Id`.header.parse(longTraceId).map(`X-B3-Span-Id`.header.value)
-      traceId shouldBe Right(longTraceId.take(16))
-      spanId shouldBe Right(longTraceId.take(16))
-    }
+  test("Truncate B3 trace & span headers to their first 64 bits") {
+    val longTraceId: String = "463ac35c9f6413ad48485a3953bb6124"
+    val traceId = `X-B3-Trace-Id`.header.parse(longTraceId).map(`X-B3-Trace-Id`.header.value)
+    val spanId = `X-B3-Span-Id`.header.parse(longTraceId).map(`X-B3-Span-Id`.header.value)
+    assertEquals(traceId, Right(longTraceId.take(16)))
+    assertEquals(spanId, Right(longTraceId.take(16)))
   }
 }

--- a/natchez-extras-dogstatsd/src/test/scala/com/ovoenergy/natchez/extras/dogstatsd/DatadogTest.scala
+++ b/natchez-extras-dogstatsd/src/test/scala/com/ovoenergy/natchez/extras/dogstatsd/DatadogTest.scala
@@ -41,7 +41,7 @@ class DatadogTest extends ScalaCheckSuite {
 
   test("Serialisation should allow through dots") {
     Prop.forAll(Gen.alphaNumStr, Gen.alphaNumStr) { (pref, suf) =>
-      filterName(s"$pref.$suf") == s"$pref.$suf".dropWhile(!_.isLetter)
+      assertEquals(filterName(s"$pref.$suf"), s"$pref.$suf".dropWhile(!_.isLetter))
     }
   }
 
@@ -51,10 +51,10 @@ class DatadogTest extends ScalaCheckSuite {
 
   test("Serialisation should generate correct counters and histograms with no tags") {
     Prop.forAll(Arbitrary.arbLong.arbitrary) { l =>
-      makeString(serialiseCounter(Metric("foo", Map.empty), l)) == s"foo:$l|c" &&
-      makeString(serialiseHistogram(Metric("foo", Map.empty), l)) == s"foo:$l|h|@1.0" &&
-      makeString(serialiseGauge(Metric("foo", Map.empty), l)) == s"foo:$l|g" &&
-      makeString(serialiseDistribution(Metric("foo", Map.empty), l)) == s"foo:$l|d|@1.0"
+      assertEquals(makeString(serialiseCounter(Metric("foo", Map.empty), l)), s"foo:$l|c")
+      assertEquals(makeString(serialiseHistogram(Metric("foo", Map.empty), l)), s"foo:$l|h|@1.0")
+      assertEquals(makeString(serialiseGauge(Metric("foo", Map.empty), l)), s"foo:$l|g")
+      assertEquals(makeString(serialiseDistribution(Metric("foo", Map.empty), l)), s"foo:$l|d|@1.0")
     }
   }
 
@@ -98,7 +98,7 @@ class DatadogTest extends ScalaCheckSuite {
   test("Config should separate the global prefix from the metric name with a dot") {
     Prop.forAll(string) { prefix =>
       val config = Config(localAddress, Some(prefix), Map("bar" -> "boz"))
-      applyConfig(Metric("foo", Map.empty), config).name == s"$prefix.foo"
+      assertEquals(applyConfig(Metric("foo", Map.empty), config).name, s"$prefix.foo")
     }
   }
 }

--- a/natchez-extras-dogstatsd/src/test/scala/com/ovoenergy/natchez/extras/dogstatsd/DatadogTest.scala
+++ b/natchez-extras-dogstatsd/src/test/scala/com/ovoenergy/natchez/extras/dogstatsd/DatadogTest.scala
@@ -4,16 +4,13 @@ import com.comcast.ip4s.{IpAddress, Port, SocketAddress}
 import com.ovoenergy.natchez.extras.dogstatsd.Dogstatsd._
 import com.ovoenergy.natchez.extras.dogstatsd.Events.{AlertType, Event, Priority}
 import com.ovoenergy.natchez.extras.metrics.Metrics.Metric
+import munit.ScalaCheckSuite
 import org.scalacheck.Gen.mapOf
 import org.scalacheck.{Arbitrary, Gen, Prop}
-import org.scalatest.matchers.should.Matchers
-import org.scalatest.wordspec.AnyWordSpec
-import org.scalatestplus.scalacheck.Checkers
-import org.typelevel.claimant.Claim
 
 import java.nio.charset.StandardCharsets.UTF_8
 
-class DatadogTest extends AnyWordSpec with Matchers with Checkers {
+class DatadogTest extends ScalaCheckSuite {
 
   val string: Gen[String] =
     Arbitrary.arbString.arbitrary
@@ -36,94 +33,72 @@ class DatadogTest extends AnyWordSpec with Matchers with Checkers {
       tags <- stringTags
     } yield Metric(name, tags)
 
-  "Datadog serialisation" should {
-
-    "Never submit double underscores to datadog" in {
-      check(
-        Prop.forAll(string) { str =>
-          !filterName(str).matches(".*?__.*?")
-        }
-      )
-    }
-
-    "Allow through dots" in {
-      check(
-        Prop.forAll(Gen.alphaNumStr, Gen.alphaNumStr) {
-          case (pref, suf) =>
-            filterName(s"$pref.$suf") == s"$pref.$suf".dropWhile(!_.isLetter)
-        }
-      )
-    }
-
-    "Allow numbers, hyphens and slashes for tag values" in {
-      filterTagValue("/12412-1231") shouldBe "/12412-1231"
-    }
-
-    "Generate correct counters and histograms with no tags" in {
-      check(
-        Prop.forAll(Arbitrary.arbLong.arbitrary) { l =>
-          makeString(serialiseCounter(Metric("foo", Map.empty), l)) == s"foo:$l|c" &&
-          makeString(serialiseHistogram(Metric("foo", Map.empty), l)) == s"foo:$l|h|@1.0" &&
-          makeString(serialiseGauge(Metric("foo", Map.empty), l)) == s"foo:$l|g" &&
-          makeString(serialiseDistribution(Metric("foo", Map.empty), l)) == s"foo:$l|d|@1.0"
-        }
-      )
-    }
-
-    "Generate correct counters & histograms with tags" in {
-      check(
-        Prop.forAllNoShrink(stringTags.suchThat(_.nonEmpty)) { rawTags =>
-          val tags = rawTags.filter { case (k, v) => s"$k$v".length <= 200 }.take(20)
-          val exp = tags.map { case (k, v) => s"${filterName(k)}:${filterTagValue(v)}" }.mkString(",")
-          Claim(makeString(serialiseHistogram(Metric("foo", tags), 1)) == s"foo:1|h|@1.0|#$exp") &&
-          Claim(makeString(serialiseCounter(Metric("foo", tags), 1)) == s"foo:1|c|#$exp") &&
-          Claim(makeString(serialiseGauge(Metric("foo", tags), 1)) == s"foo:1|g|#$exp") &&
-          Claim(makeString(serialiseDistribution(Metric("foo", tags), 1)) == s"foo:1|d|@1.0|#$exp")
-        }
-      )
-    }
-
-    "Limit the size of a UDP packet to below the maximum 65535 bytes" in {
-      check(
-        Prop.forAllNoShrink(string, stringTags) {
-          case (name, tags) =>
-            Claim(serialiseHistogram(Metric(name, tags), 1).length < 65535) &&
-            Claim(serialiseCounter(Metric(name, tags), 1).length < 65535) &&
-            Claim(serialiseGauge(Metric(name, tags), 1).length < 65535) &&
-            Claim(serialiseDistribution(Metric(name, tags), 1).length < 65535)
-        }
-      )
-    }
-
-    "Generate correct events" in {
-      val res = serialiseEvent(Event("fooo", "bar\nbaz", AlertType.Info, Map.empty, Priority.Normal))
-      makeString(res) shouldBe "_e{4,8}:fooo|bar\\nbaz|t:info|p:normal"
+  test("Serialisation should never submit double underscores to datadog") {
+    Prop.forAll(string) { str =>
+      !filterName(str).matches(".*?__.*?")
     }
   }
 
-  "Configuration" should {
-
-    "Not overwrite existing tags" in {
-      val config = Config(localAddress, None, Map("bar" -> "boz"))
-      applyConfig(Metric("foo", Map("bar" -> "baz")), config).tags shouldBe Map("bar" -> "baz")
+  test("Serialisation should allow through dots") {
+    Prop.forAll(Gen.alphaNumStr, Gen.alphaNumStr) { (pref, suf) =>
+      filterName(s"$pref.$suf") == s"$pref.$suf".dropWhile(!_.isLetter)
     }
+  }
 
-    "Add new tags where they're not specified" in {
-      check(
-        Prop.forAll(stringTags) { ts =>
-          val config = Config(localAddress, None, ts)
-          applyConfig(Metric("foo", Map.empty), config).tags == ts
-        }
-      )
+  test("Serialisation should allow numbers, hyphens and slashes for tag values") {
+    assertEquals(filterTagValue("/12412-1231"), "/12412-1231")
+  }
+
+  test("Serialisation should generate correct counters and histograms with no tags") {
+    Prop.forAll(Arbitrary.arbLong.arbitrary) { l =>
+      makeString(serialiseCounter(Metric("foo", Map.empty), l)) == s"foo:$l|c" &&
+      makeString(serialiseHistogram(Metric("foo", Map.empty), l)) == s"foo:$l|h|@1.0" &&
+      makeString(serialiseGauge(Metric("foo", Map.empty), l)) == s"foo:$l|g" &&
+      makeString(serialiseDistribution(Metric("foo", Map.empty), l)) == s"foo:$l|d|@1.0"
     }
+  }
 
-    "Separate the global prefix from the metric name with a dot" in {
-      check(
-        Prop.forAll(string) { prefix =>
-          val config = Config(localAddress, Some(prefix), Map("bar" -> "boz"))
-          applyConfig(Metric("foo", Map.empty), config).name == s"$prefix.foo"
-        }
-      )
+  test("Serialisation should generate correct counters & histograms with tags") {
+    Prop.forAllNoShrink(stringTags.suchThat(_.nonEmpty)) { rawTags =>
+      val tags = rawTags.filter { case (k, v) => s"$k$v".length <= 200 }.take(20)
+      val exp = tags.map { case (k, v) => s"${filterName(k)}:${filterTagValue(v)}" }.mkString(",")
+      assertEquals(makeString(serialiseHistogram(Metric("foo", tags), 1)), s"foo:1|h|@1.0|#$exp")
+      assertEquals(makeString(serialiseCounter(Metric("foo", tags), 1)), s"foo:1|c|#$exp")
+      assertEquals(makeString(serialiseGauge(Metric("foo", tags), 1)), s"foo:1|g|#$exp")
+      assertEquals(makeString(serialiseDistribution(Metric("foo", tags), 1)), s"foo:1|d|@1.0|#$exp")
+    }
+  }
+
+  test("Serialisation should limit the size of a UDP packet to below the maximum 65535 bytes") {
+    Prop.forAllNoShrink(string, stringTags) { (name, tags) =>
+      assert(serialiseHistogram(Metric(name, tags), 1).length < 65535)
+      assert(serialiseCounter(Metric(name, tags), 1).length < 65535)
+      assert(serialiseGauge(Metric(name, tags), 1).length < 65535)
+      assert(serialiseDistribution(Metric(name, tags), 1).length < 65535)
+    }
+  }
+
+  test("Serialisation should generate correct events") {
+    val res = serialiseEvent(Event("fooo", "bar\nbaz", AlertType.Info, Map.empty, Priority.Normal))
+    assertEquals(makeString(res), "_e{4,8}:fooo|bar\\nbaz|t:info|p:normal")
+  }
+
+  test("Config should not overwrite existing tags") {
+    val config = Config(localAddress, None, Map("bar" -> "boz"))
+    assertEquals(applyConfig(Metric("foo", Map("bar" -> "baz")), config).tags, Map("bar" -> "baz"))
+  }
+
+  test("Config should add new tags where they're not specified") {
+    Prop.forAll(stringTags) { ts =>
+      val config = Config(localAddress, None, ts)
+      assertEquals(applyConfig(Metric("foo", Map.empty), config).tags, ts)
+    }
+  }
+
+  test("Config should separate the global prefix from the metric name with a dot") {
+    Prop.forAll(string) { prefix =>
+      val config = Config(localAddress, Some(prefix), Map("bar" -> "boz"))
+      applyConfig(Metric("foo", Map.empty), config).name == s"$prefix.foo"
     }
   }
 }

--- a/natchez-extras-fs2/src/test/scala/com/ovoenergy/natchez/extras/fs2/AllocatedSpanTest.scala
+++ b/natchez-extras-fs2/src/test/scala/com/ovoenergy/natchez/extras/fs2/AllocatedSpanTest.scala
@@ -1,124 +1,101 @@
 package com.ovoenergy.natchez.extras.fs2
 
-import cats.effect.IO
+import cats.effect.{IO, Resource, SyncIO}
 import cats.effect.kernel.Resource.ExitCase
 import com.ovoenergy.natchez.extras.testkit.TestEntryPoint
 import fs2.Stream
-import org.scalatest.Inspectors
-import org.scalatest.matchers.should.Matchers
-import org.scalatest.wordspec.AnyWordSpec
-import cats.effect.unsafe.implicits.global
+import munit.CatsEffectSuite
 
 import java.util.UUID
 import scala.concurrent.duration._
 
-class AllocatedSpanTest extends AnyWordSpec with Matchers {
+class AllocatedSpanTest extends CatsEffectSuite {
 
-  val testEp: IO[TestEntryPoint[IO]] =
-    TestEntryPoint.apply[IO]
+  val testEp: SyncIO[FunFixture[TestEntryPoint[IO]]] =
+    ResourceFixture(Resource.eval(TestEntryPoint.apply[IO]))
 
-  "AllocatedSpan.create" should {
+  testEp.test("should submit the span even if a pre-submit task fails") { ep =>
+    val stream: IO[Unit] =
+      Stream
+        .emit("foo")
+        .covary[IO]
+        .through(AllocatedSpan.create(maxOpen = 10)(_ => ep.root("root")))
+        .evalTap(_.span.addSubmitTask(IO.raiseError(new Exception)).submit)
+        .compile
+        .drain
 
-    "Submit the span even if a pre-submit task fails" in {
-      testEp
-        .flatMap { ep =>
-          val stream: IO[Unit] =
-            Stream
-              .emit("foo")
-              .covary[IO]
-              .through(AllocatedSpan.create(maxOpen = 10)(_ => ep.root("root")))
-              .evalTap(_.span.addSubmitTask(IO.raiseError(new Exception)).submit)
-              .compile
-              .drain
-
-          for {
-            _     <- stream.attempt
-            spans <- ep.spans
-          } yield {
-            spans.length shouldBe 1
-            spans.maxBy(_.completed).name shouldBe "root"
-            Inspectors.forAll(spans)(_.exitCase shouldBe ExitCase.Succeeded)
-          }
-        }
-        .unsafeRunSync()
+    for {
+      _     <- stream.attempt
+      spans <- ep.spans
+    } yield {
+      assertEquals(spans.length, 1)
+      assertEquals(spans.maxBy(_.completed).name, "root")
+      assertEquals(spans.map(_.exitCase), List.fill(spans.length)(ExitCase.Succeeded))
     }
+  }
 
-    "Hold the parent span open until it is explicitly submitted" in {
-      testEp
-        .flatMap { ep =>
-          val stream: IO[Unit] =
-            Stream
-              .emit("foo")
-              .covary[IO]
-              .through(AllocatedSpan.create(maxOpen = 10)(_ => ep.root("root")))
-              .evalTap(_.span.span("foo").use(_ => IO.unit))
-              .metered(5.millisecond)
-              .evalTap(_.span.submit)
-              .compile
-              .drain
+  testEp.test("Hold the parent span open until it is explicitly submitted") { ep =>
+    val stream: IO[Unit] =
+      Stream
+        .emit("foo")
+        .covary[IO]
+        .through(AllocatedSpan.create(maxOpen = 10)(_ => ep.root("root")))
+        .evalTap(_.span.span("foo").use(_ => IO.unit))
+        .metered(5.millisecond)
+        .evalTap(_.span.submit)
+        .compile
+        .drain
 
-          for {
-            _     <- stream
-            spans <- ep.spans
-          } yield {
-            spans.length shouldBe 2
-            spans.minBy(_.completed).name shouldBe "foo"
-            spans.maxBy(_.completed).name shouldBe "root"
-            Inspectors.forAll(spans)(_.exitCase shouldBe ExitCase.Succeeded)
-          }
-        }
-        .unsafeRunSync()
+    for {
+      _     <- stream
+      spans <- ep.spans
+    } yield {
+      assertEquals(spans.length, 2)
+      assertEquals(spans.minBy(_.completed).name, "foo")
+      assertEquals(spans.maxBy(_.completed).name, "root")
+      assertEquals(spans.map(_.exitCase), List.fill(spans.length)(ExitCase.Succeeded))
     }
+  }
 
-    "Cancel the allocated span if the stream dies" in {
-      testEp
-        .flatMap { ep =>
-          val stream: IO[Unit] =
-            Stream
-              .emit("foo")
-              .covary[IO]
-              .through(AllocatedSpan.create(maxOpen = 10)(_ => ep.root("bar")))
-              .evalTap(_.span.span("foo").use(_ => IO.unit))
-              .evalTap(_ => IO.raiseError(new Exception("")))
-              .compile
-              .drain
+  testEp.test("Cancel the allocated span if the stream dies") { ep =>
+    val stream: IO[Unit] =
+      Stream
+        .emit("foo")
+        .covary[IO]
+        .through(AllocatedSpan.create(maxOpen = 10)(_ => ep.root("bar")))
+        .evalTap(_.span.span("foo").use(_ => IO.unit))
+        .evalTap(_ => IO.raiseError(new Exception("")))
+        .compile
+        .drain
 
-          for {
-            _     <- stream.attempt
-            spans <- ep.spans
-          } yield {
-            spans.length shouldBe 2
-            val last = spans.maxBy(_.completed)
-            val first = spans.minBy(_.completed)
-
-            last.exitCase shouldBe ExitCase.Canceled
-            first.exitCase shouldBe ExitCase.Succeeded
-          }
-        }
-        .unsafeRunSync()
+    for {
+      _     <- stream.attempt
+      spans <- ep.spans
+    } yield {
+      assertEquals(spans.length, 2)
+      val last = spans.maxBy(_.completed)
+      val first = spans.minBy(_.completed)
+      assertEquals(last.exitCase, ExitCase.Canceled)
+      assertEquals(first.exitCase, ExitCase.Succeeded)
     }
+  }
 
-    "Work with extremely parallel streams" in {
-      testEp
-        .flatMap { ep =>
-          val stream: IO[Unit] =
-            Stream
-              .repeatEval(IO.delay(UUID.randomUUID()))
-              .take(50)
-              .through(AllocatedSpan.create(maxOpen = 10)(_ => ep.root("root")))
-              .parEvalMap(maxConcurrent = 50) { s =>
-                s.span.span("foo").use(_ => IO(s))
-              }
-              .evalMap(_.span.submit)
-              .compile
-              .drain
-
-          for {
-            _     <- stream.attempt
-            spans <- ep.spans
-          } yield spans.length shouldBe 100
+  testEp.test("Work with extremely parallel streams") { ep =>
+    val stream: IO[Unit] =
+      Stream
+        .repeatEval(IO.delay(UUID.randomUUID()))
+        .take(50)
+        .through(AllocatedSpan.create(maxOpen = 10)(_ => ep.root("root")))
+        .parEvalMap(maxConcurrent = 50) { s =>
+          s.span.span("foo").use(_ => IO(s))
         }
-        .unsafeRunSync()
-    }
+        .evalMap(_.span.submit)
+        .compile
+        .drain
+
+    assertIO(
+      returns = 100,
+      obtained = stream.attempt >> ep.spans.map(_.length)
+    )
   }
 }

--- a/natchez-extras-http4s/src/test/scala/com/ovoenergy/natchez/extras/http4s/client/TracedClientTest.scala
+++ b/natchez-extras-http4s/src/test/scala/com/ovoenergy/natchez/extras/http4s/client/TracedClientTest.scala
@@ -2,57 +2,43 @@ package com.ovoenergy.natchez.extras.http4s.client
 
 import cats.data.Kleisli
 import cats.effect.IO
-import cats.effect.unsafe.implicits.global
 import com.ovoenergy.natchez.extras.http4s.Configuration
 import com.ovoenergy.natchez.extras.testkit.TestEntryPoint
-import com.ovoenergy.natchez.extras.testkit.TestEntryPoint.CompletedSpan
+import munit.CatsEffectSuite
 import natchez.{Kernel, Span}
 import org.http4s.{Header, Request}
-import org.scalatest.Inspectors
-import org.scalatest.matchers.should.Matchers
-import org.scalatest.wordspec.AnyWordSpec
 import org.typelevel.ci._
 
-class TracedClientTest extends AnyWordSpec with Matchers {
+class TracedClientTest extends CatsEffectSuite {
 
   val unit: Kleisli[IO, Span[IO], Unit] = Kleisli.pure(())
   val config: Configuration[IO] = Configuration.default[IO]()
   type TraceIO[A] = Kleisli[IO, Span[IO], A]
 
-  "TracedClient" should {
+  test("Add the kernel to requests") {
+    for {
+      client <- TestClient[IO]
+      ep     <- TestEntryPoint[IO]
+      http = TracedClient(client.client, config)
+      kernel = Kernel(Map("X-Trace-Token" -> "token"))
+      _    <- ep.continue("bar", kernel).use(http.named("foo").status(Request[TraceIO]()).run)
+      reqs <- client.requests
+    } yield assertEquals(
+      obtained = reqs.flatMap(_.headers.headers).filter(_.name == ci"X-Trace-Token"),
+      expected = List(Header.Raw(ci"X-Trace-Token", "token"))
+    )
+  }
 
-    "Add the kernel to requests" in {
-
-      val requests: List[Request[IO]] = (
-        for {
-          client <- TestClient[IO]
-          ep     <- TestEntryPoint[IO]
-          http = TracedClient(client.client, config)
-          kernel = Kernel(Map("X-Trace-Token" -> "token"))
-          _    <- ep.continue("bar", kernel).use(http.named("foo").status(Request[TraceIO]()).run)
-          reqs <- client.requests
-        } yield reqs
-      ).unsafeRunSync()
-
-      Inspectors.forAll(requests) { req =>
-        req.headers.headers should contain(Header.Raw(ci"X-Trace-Token", "token"))
-      }
-    }
-
-    "Create a new span for HTTP requests" in {
-
-      val spans: List[CompletedSpan] = (
-        for {
-          client <- TestClient[IO]
-          ep     <- TestEntryPoint[IO]
-          http = TracedClient(client.client, config)
-          _    <- ep.root("root").use(http.named("foo").status(Request[TraceIO]()).run)
-          reqs <- ep.spans
-        } yield reqs
-      ).unsafeRunSync()
-
-      spans.length shouldBe 2
-      spans.head.name shouldBe "foo:http.request:/"
+  test("Create a new span for HTTP requests") {
+    for {
+      client <- TestClient[IO]
+      ep     <- TestEntryPoint[IO]
+      http = TracedClient(client.client, config)
+      _     <- ep.root("root").use(http.named("foo").status(Request[TraceIO]()).run)
+      spans <- ep.spans
+    } yield {
+      assertEquals(spans.length, 2)
+      assertEquals(spans.head.name, "foo:http.request:/")
     }
   }
 }

--- a/natchez-extras-http4s/src/test/scala/com/ovoenergy/natchez/extras/http4s/server/SyntaxTest.scala
+++ b/natchez-extras-http4s/src/test/scala/com/ovoenergy/natchez/extras/http4s/server/SyntaxTest.scala
@@ -1,29 +1,22 @@
 package com.ovoenergy.natchez.extras.http4s.server
 
 import cats.effect.IO
-import cats.effect.unsafe.implicits._
 import com.ovoenergy.natchez.extras.http4s.server.syntax._
+import munit.CatsEffectSuite
 import org.http4s.Status.{InsufficientStorage, Ok}
 import org.http4s.{HttpApp, HttpRoutes, Request, Response}
-import org.scalatest.matchers.should.Matchers
-import org.scalatest.wordspec.AnyWordSpec
 
-class SyntaxTest extends AnyWordSpec with Matchers {
+class SyntaxTest extends CatsEffectSuite {
 
-  "fallThroughTo" should {
+  test("Call the second Kleisli if the first returns None") {
+    val routes: HttpRoutes[IO] = HttpRoutes.empty
+    val app: HttpApp[IO] = HttpApp.pure(Response(status = Ok))
+    assertIO(routes.fallthroughTo(app).run(Request()).map(_.status), Ok)
+  }
 
-    "Call the second Kleisli if the first returns None" in {
-      val routes: HttpRoutes[IO] = HttpRoutes.empty
-      val app: HttpApp[IO] = HttpApp.pure(Response(status = Ok))
-      val result = routes.fallthroughTo(app).run(Request()).unsafeRunSync()
-      result.status shouldBe Ok
-    }
-
-    "Not call the second Kleisli if the first returns a result" in {
-      val routes: HttpRoutes[IO] = HttpRoutes.pure(Response(status = Ok))
-      val app: HttpApp[IO] = HttpApp.pure(Response(status = InsufficientStorage))
-      val result = routes.fallthroughTo(app).run(Request()).unsafeRunSync()
-      result.status shouldBe Ok
-    }
+  test("Not call the second Kleisli if the first returns a result") {
+    val routes: HttpRoutes[IO] = HttpRoutes.pure(Response(status = Ok))
+    val app: HttpApp[IO] = HttpApp.pure(Response(status = InsufficientStorage))
+    assertIO(routes.fallthroughTo(app).run(Request()).map(_.status), Ok)
   }
 }

--- a/natchez-extras-http4s/src/test/scala/com/ovoenergy/natchez/extras/http4s/server/TraceMiddlewareTest.scala
+++ b/natchez-extras-http4s/src/test/scala/com/ovoenergy/natchez/extras/http4s/server/TraceMiddlewareTest.scala
@@ -1,57 +1,22 @@
 package com.ovoenergy.natchez.extras.http4s.server
 
 import cats.data.Kleisli
-import cats.effect.Ref
-import cats.effect.{IO, Resource}
-import cats.{Applicative, Monad}
+import cats.effect.IO
 import com.ovoenergy.natchez.extras.http4s.Configuration
+import com.ovoenergy.natchez.extras.testkit.TestEntryPoint
 import fs2._
-import natchez.TraceValue.{NumberValue, StringValue}
-import natchez.{EntryPoint, Kernel, Span, TraceValue}
+import munit.CatsEffectSuite
+import natchez.{Span, TraceValue}
 import org.http4s.Status._
 import org.http4s._
 import org.http4s.headers._
 import org.http4s.syntax.literals._
-import org.scalatest.Inspectors
-import org.scalatest.matchers.should.Matchers
-import cats.effect.unsafe.implicits.global
-import org.scalatest.wordspec.AnyWordSpec
 
-import java.net.URI
-
-class TraceMiddlewareTest extends AnyWordSpec with Matchers with Inspectors {
+class TraceMiddlewareTest extends CatsEffectSuite {
   type TraceIO[A] = Kleisli[IO, Span[IO], A]
 
   val config: Configuration[IO] =
     Configuration.default[IO]()
-
-  def spanMock[F[_]: Applicative](ref: Ref[F, Map[String, TraceValue]]): Span[F] =
-    new Span[F] {
-      def kernel: F[Kernel] = Applicative[F].pure(Kernel(Map.empty))
-      def put(fields: (String, TraceValue)*): F[Unit] = ref.update(_ ++ fields.toMap)
-      def span(name: String): Resource[F, Span[F]] = Resource.pure(spanMock[F](ref))
-      def traceId: F[Option[String]] = Applicative[F].pure(None)
-      def spanId: F[Option[String]] = Applicative[F].pure(None)
-      def traceUri: F[Option[URI]] = Applicative[F].pure(None)
-    }
-
-  trait TestEntryPoint[F[_]] extends EntryPoint[F] {
-    def tags: F[Map[String, TraceValue]]
-  }
-
-  def entrypointMock: IO[TestEntryPoint[IO]] =
-    Ref.of[IO, Map[String, TraceValue]](Map.empty).map { ref =>
-      new TestEntryPoint[IO] {
-        def root(name: String): Resource[IO, Span[IO]] =
-          Resource.eval(Monad[IO].pure(spanMock(ref)))
-        def continue(name: String, kernel: Kernel): Resource[IO, Span[IO]] =
-          Resource.eval(Monad[IO].pure(spanMock(ref)))
-        def continueOrElseRoot(name: String, kernel: Kernel): Resource[IO, Span[IO]] =
-          Resource.eval(Monad[IO].pure(spanMock(ref)))
-        def tags: IO[Map[String, TraceValue]] =
-          ref.get
-      }
-    }
 
   def okService(body: String, headers: Headers = Headers.empty): HttpRoutes[TraceIO] =
     Kleisli.pure(Response[TraceIO](Ok, headers = headers, body = Stream.emits(body.getBytes)))
@@ -62,108 +27,106 @@ class TraceMiddlewareTest extends AnyWordSpec with Matchers with Inspectors {
   val noContentService: HttpRoutes[TraceIO] =
     Kleisli.pure(Response(InternalServerError))
 
-  "Logging / tracing middleware" should {
-    def s(string: String): StringValue = StringValue(string)
+  test("Add tracing info & log requests + responses") {
+    assertIO(
+      returns = Map[String, TraceValue](
+        "span.type" -> "web",
+        "http.url" -> "/",
+        "http.method" -> "GET",
+        "http.status_code" -> 200,
+        "http.request.headers" -> "X-Trace-Token: foobar\n",
+        "http.response.headers" -> "",
+        "http.url" -> "/"
+      ),
+      obtained = for {
+        entryPoint <- TestEntryPoint[IO]
+        svc = TraceMiddleware[IO](entryPoint, config)(okService("ok").orNotFound)
+        _     <- svc.run(Request(headers = Headers("X-Trace-Token" -> "foobar")))
+        spans <- entryPoint.spans
+      } yield spans.head.tags.toMap
+    )
+  }
 
-    "Add tracing info & log requests + responses" in {
-      (
-        for {
-          entryPoint <- entrypointMock
-          svc = TraceMiddleware[IO](entryPoint, config)(okService("ok").orNotFound)
-          _    <- svc.run(Request(headers = Headers("X-Trace-Token" -> "foobar")))
-          tags <- entryPoint.tags
-        } yield tags shouldBe Map(
-          "span.type" -> s("web"),
-          "http.url" -> s("/"),
-          "http.method" -> s("GET"),
-          "http.status_code" -> NumberValue(200),
-          "http.request.headers" -> s("X-Trace-Token: foobar\n"),
-          "http.response.headers" -> s(""),
-          "http.url" -> s("/")
-        )
-      ).unsafeRunSync()
-    }
+  test("Log headers, redacting any sensitive ones") {
 
-    "Log headers, redacting any sensitive ones" in {
+    val responseHeaders = Headers(
+      `Set-Cookie`(ResponseCookie("secret", "foo")),
+      "X-Polite" -> "come back soon!"
+    )
 
-      val responseHeaders = Headers(
-        `Set-Cookie`(ResponseCookie("secret", "foo")),
-        "X-Polite" -> "come back soon!"
-      )
+    val requestHeaders = Headers(
+      Authorization(BasicCredentials("secret")),
+      Cookie(RequestCookie("secret", "secret")),
+      `Content-Type`(MediaType.`text/event-stream`)
+    )
 
-      val requestHeaders = Headers(
-        Authorization(BasicCredentials("secret")),
-        Cookie(RequestCookie("secret", "secret")),
-        `Content-Type`(MediaType.`text/event-stream`)
-      )
+    assertIO(
+      returns = Map[String, TraceValue](
+        "span.type" -> "web",
+        "http.url" -> "/",
+        "http.method" -> "GET",
+        "http.response.headers" -> "",
+        "http.status_code" -> 200,
+        "http.request.headers" ->
+        """|Authorization: <REDACTED>
+           |Cookie: <REDACTED>
+           |Content-Type: text/event-stream
+           |""".stripMargin,
+        "http.response.headers" ->
+        """|Set-Cookie: <REDACTED>
+           |X-Polite: come back soon!
+           |""".stripMargin
+      ),
+      obtained = for {
+        entryPoint <- TestEntryPoint[IO]
+        svc = TraceMiddleware[IO](entryPoint, config)(okService("", responseHeaders).orNotFound)
+        _     <- svc.run(Request(headers = requestHeaders))
+        spans <- entryPoint.spans
+      } yield spans.head.tags.toMap
+    )
+  }
 
-      (
-        for {
-          entryPoint <- entrypointMock
-          svc = TraceMiddleware[IO](entryPoint, config)(okService("", responseHeaders).orNotFound)
-          _    <- svc.run(Request(headers = requestHeaders))
-          tags <- entryPoint.tags
-        } yield tags shouldBe Map(
-          "span.type" -> s("web"),
-          "http.url" -> s("/"),
-          "http.method" -> s("GET"),
-          "http.response.headers" -> s(""),
-          "http.status_code" -> NumberValue(200),
-          "http.request.headers" -> s(
-            """|Authorization: <REDACTED>
-               |Cookie: <REDACTED>
-               |Content-Type: text/event-stream
-               |""".stripMargin
-          ),
-          "http.response.headers" -> s(
-            """|Set-Cookie: <REDACTED>
-               |X-Polite: come back soon!
-               |""".stripMargin
-          )
-        )
-      ).unsafeRunSync()
-    }
+  test("Include the response body if the response is an error") {
+    assertIO(
+      returns = Map[String, TraceValue](
+        "span.type" -> "web",
+        "http.method" -> "GET",
+        "http.status_code" -> 500,
+        "http.response.entity" -> "oh no",
+        "http.response.headers" -> "",
+        "http.request.headers" -> "",
+        "http.url" -> "/"
+      ),
+      obtained = for {
+        entryPoint <- TestEntryPoint[IO]
+        svc = TraceMiddleware[IO](entryPoint, config)(errorService("oh no").orNotFound)
+        _     <- svc.run(Request())
+        spans <- entryPoint.spans
+      } yield spans.head.tags.toMap
+    )
+  }
 
-    "Include the response body if the response is an error" in {
-      (
-        for {
-          entryPoint <- entrypointMock
-          svc = TraceMiddleware[IO](entryPoint, config)(errorService("oh no").orNotFound)
-          _    <- svc.run(Request())
-          tags <- entryPoint.tags
-        } yield tags shouldBe Map(
-          "span.type" -> s("web"),
-          "http.method" -> s("GET"),
-          "http.status_code" -> NumberValue(500),
-          "http.response.entity" -> s("oh no"),
-          "http.response.headers" -> s(""),
-          "http.request.headers" -> s(""),
-          "http.url" -> s("/")
-        )
-      ).unsafeRunSync()
-    }
+  test("Not include the response body if there isn't one on the response") {
+    assertIO(
+      returns = Map[String, TraceValue](
+        "span.type" -> "web",
+        "http.method" -> "GET",
+        "http.status_code" -> 500,
+        "http.response.headers" -> "",
+        "http.request.headers" -> "",
+        "http.url" -> "/"
+      ),
+      obtained = for {
+        entryPoint <- TestEntryPoint[IO]
+        svc = TraceMiddleware[IO](entryPoint, config)(noContentService.orNotFound)
+        _     <- svc.run(Request())
+        spans <- entryPoint.spans
+      } yield spans.head.tags.toMap
+    )
+  }
 
-    "Not include the response body if there isn't one on the response" in {
-      (
-        for {
-          entryPoint <- entrypointMock
-          svc = TraceMiddleware[IO](entryPoint, config)(noContentService.orNotFound)
-          _    <- svc.run(Request())
-          tags <- entryPoint.tags
-        } yield tags shouldBe Map(
-          "span.type" -> s("web"),
-          "http.method" -> s("GET"),
-          "http.status_code" -> NumberValue(500),
-          "http.response.headers" -> s(""),
-          "http.request.headers" -> s(""),
-          "http.url" -> s("/")
-        )
-      ).unsafeRunSync()
-    }
-
-    "convert URI to a tag-friendly version" in {
-      val uri = uri"https://test.com/test/path/ACC-1234/CUST-456/test"
-      TraceMiddleware.removeNumericPathSegments(uri) shouldBe "/test/path/_/_/test"
-    }
+  test("convert URI to a tag-friendly version") {
+    val uri = uri"https://test.com/test/path/ACC-1234/CUST-456/test"
+    assertEquals(TraceMiddleware.removeNumericPathSegments(uri), "/test/path/_/_/test")
   }
 }

--- a/natchez-extras-slf4j/src/test/scala/com/ovoenergy/natchez/extras/slf4j/Slf4jSpanTest.scala
+++ b/natchez-extras-slf4j/src/test/scala/com/ovoenergy/natchez/extras/slf4j/Slf4jSpanTest.scala
@@ -1,73 +1,78 @@
 package com.ovoenergy.natchez.extras.slf4j
 
 import cats.effect.{Concurrent, IO}
+import munit.CatsEffectSuite
 import natchez.Kernel
-import org.scalatest.BeforeAndAfterEach
-import org.scalatest.matchers.should.Matchers
-import org.scalatest.wordspec.AnyWordSpec
 import uk.org.lidalia.slf4jtest.{LoggingEvent, TestLoggerFactory}
-import cats.effect.unsafe.implicits.global
 
 import scala.concurrent.duration.DurationInt
 import scala.jdk.CollectionConverters._
-import scala.util.Try
 
-class Slf4jSpanTest extends AnyWordSpec with Matchers with BeforeAndAfterEach {
+class Slf4jSpanTest extends CatsEffectSuite {
 
-  override def beforeEach(): Unit =
+  override def beforeEach(context: BeforeEach): Unit =
     TestLoggerFactory.clearAll()
 
-  val flushLogs: IO[List[LoggingEvent]] =
+  val flushLogMessages: IO[List[LoggingEvent]] =
     IO.delay {
       val logs = TestLoggerFactory.getAllLoggingEvents.asScala.toList
       TestLoggerFactory.clearAll()
       logs
     }
 
-  "Slf4j span logging" should {
+  val flushLogs: IO[List[String]] =
+    flushLogMessages.map(_.map(_.getMessage))
 
-    "Log something when the span is created" in {
-      val started = Slf4jSpan.create[IO]("foo").use(_ => flushLogs).unsafeRunSync()
-      started.map(_.getMessage) shouldBe List("foo started")
-    }
+  test("should log something when the span is created") {
+    assertIO(
+      obtained = Slf4jSpan.create[IO]("foo").use(_ => flushLogs),
+      returns = List("foo started")
+    )
+  }
 
-    "Log successes" in {
-      Slf4jSpan.create[IO]("foo").use(_ => flushLogs).unsafeRunSync()
-      flushLogs.unsafeRunSync().map(_.getMessage) shouldBe List("foo success")
-    }
+  test("should log successes") {
+    assertIO(
+      obtained = Slf4jSpan.create[IO]("foo").use(_ => flushLogs) >> flushLogs,
+      returns = List("foo success")
+    )
+  }
 
-    "Log cancelled tasks" in {
-      val task: IO[List[LoggingEvent]] = Slf4jSpan.create[IO]("foo").use(_ => flushLogs >> IO.never)
-      val result =
-        Concurrent[IO].start(task).flatMap(t => IO.sleep(1.milli) >> t.cancel >> flushLogs).unsafeRunSync()
-      result.map(_.getMessage) shouldBe List("foo cancelled")
-    }
+  test("should Log cancelled tasks") {
+    val task: IO[List[LoggingEvent]] = Slf4jSpan.create[IO]("foo").use(_ => flushLogs >> IO.never)
+    assertIO(
+      returns = List("foo cancelled"),
+      obtained = Concurrent[IO].start(task).flatMap { t =>
+        IO.sleep(1.milli) >> t.cancel >> flushLogs
+      }
+    )
+  }
 
-    "Log failed tasks" in {
-      val explode = flushLogs >> IO.raiseError(new Exception("boo"))
-      Try(Slf4jSpan.create[IO]("foo").use(_ => explode).unsafeRunSync())
-      val logs = flushLogs.unsafeRunSync()
-      logs.map(_.getMessage) shouldBe List("foo error")
-      logs.map(_.getThrowable.get().getMessage) shouldBe List("boo")
-    }
-
-    "Include trace tokens" in {
-      Slf4jSpan.create[IO]("foo", token = Some("bar")).use(IO.pure).unsafeRunSync()
-      flushLogs.unsafeRunSync().map(_.getMdc.asScala) shouldBe List.fill(2)(Map("traceToken" -> "bar"))
+  test("Log failed tasks") {
+    val explode = flushLogs >> IO.raiseError(new Exception("boo"))
+    (Slf4jSpan.create[IO]("foo").use(_ => explode).attempt >> flushLogMessages).map { logs =>
+      assertEquals(logs.map(_.getThrowable.get().getMessage), List("boo"))
+      assertEquals(logs.map(_.getMessage), List("foo error"))
     }
   }
 
-  "Slf4j span fromKernel" should {
-
-    "Fail if the kernel does not contain a trace token" in {
-      val res = Slf4jSpan.fromKernel[IO]("foo", Kernel(Map.empty)).attempt.unsafeRunSync()
-      res should matchPattern { case Left(_) => }
-    }
-
-    "Succeed regardless of the case of the trace token" in {
-      val res = Slf4jSpan.fromKernel[IO]("foo", Kernel(Map("x-Trace-TOKEN" -> "boz")))
-      res.unsafeRunSync().use(s => IO(s.token)).unsafeRunSync() shouldBe "boz"
-    }
+  test("Include trace tokens") {
+    assertIO(
+      returns = List.fill(2)(Map("traceToken" -> "bar")),
+      obtained = Slf4jSpan.create[IO]("foo", token = Some("bar")).use(IO.pure) >>
+        flushLogMessages.map(_.map(_.getMdc.asScala.toMap))
+    )
   }
 
+  test("fromKernel should fail if the kernel does not contain a trace token") {
+    assertIOBoolean(Slf4jSpan.fromKernel[IO]("foo", Kernel(Map.empty)).attempt.map(_.isLeft))
+  }
+
+  test("fromKernel should succeed regardless of the case of the trace token") {
+    assertIO(
+      returns = "boz",
+      obtained = Slf4jSpan
+        .fromKernel[IO]("foo", Kernel(Map("x-Trace-TOKEN" -> "boz")))
+        .flatMap(_.use(r => IO(r.token)))
+    )
+  }
 }

--- a/natchez-extras-testkit/src/test/scala/com/ovoenergy/natchez/extras/testkit/TestEntryPointTest.scala
+++ b/natchez-extras-testkit/src/test/scala/com/ovoenergy/natchez/extras/testkit/TestEntryPointTest.scala
@@ -2,23 +2,20 @@ package com.ovoenergy.natchez.extras.testkit
 
 import cats.effect.IO
 import cats.effect.kernel.Resource.ExitCase.Succeeded
-import cats.effect.unsafe.implicits._
 import com.ovoenergy.natchez.extras.testkit.TestEntryPoint.CompletedSpan
+import munit.CatsEffectSuite
 import natchez.{Kernel, TraceValue}
-import org.scalatest.matchers.should.Matchers
-import org.scalatest.wordspec.AnyWordSpec
 
 import java.time.Instant.EPOCH
 
-class TestEntryPointTest extends AnyWordSpec with Matchers {
+class TestEntryPointTest extends CatsEffectSuite {
 
   val testKernel: Kernel =
     Kernel(Map("test" -> "header"))
 
-  "TestEntryPoint" should {
-
-    "Capture tags sent along with each span" in {
-      TestEntryPoint[IO]
+  test("TestEntryPoint should capture tags sent along with each span") {
+    assertIO(
+      obtained = TestEntryPoint[IO]
         .flatMap { ep =>
           ep.continue("root-span", testKernel).use { root =>
             root.put("tag" -> "root-span") >> root.span("sub-span").use { span =>
@@ -27,26 +24,26 @@ class TestEntryPointTest extends AnyWordSpec with Matchers {
           } >> ep.spans
         }
         .map { results =>
-          results.map(_.copy(completed = EPOCH)) shouldBe List(
-            CompletedSpan(
-              tags = List("tag" -> ("sub-span": TraceValue)),
-              parent = Some("root-span"),
-              completed = EPOCH,
-              exitCase = Succeeded,
-              kernel = testKernel,
-              name = "sub-span"
-            ),
-            CompletedSpan(
-              tags = List("tag" -> ("root-span": TraceValue)),
-              parent = None,
-              completed = EPOCH,
-              exitCase = Succeeded,
-              kernel = testKernel,
-              name = "root-span"
-            )
-          )
-        }
-        .unsafeRunSync()
-    }
+          results.map(_.copy(completed = EPOCH))
+        },
+      returns = List(
+        CompletedSpan(
+          tags = List("tag" -> ("sub-span": TraceValue)),
+          parent = Some("root-span"),
+          completed = EPOCH,
+          exitCase = Succeeded,
+          kernel = testKernel,
+          name = "sub-span"
+        ),
+        CompletedSpan(
+          tags = List("tag" -> ("root-span": TraceValue)),
+          parent = None,
+          completed = EPOCH,
+          exitCase = Succeeded,
+          kernel = testKernel,
+          name = "root-span"
+        )
+      )
+    )
   }
 }


### PR DESCRIPTION
I'm doing this because MUnit has nice built in case class diffs so we can remove Claimant, which is deprecated and not available for Scala 3