### PR TITLE
Publish natchez-extras-core package

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -204,7 +204,6 @@ lazy val core = project
   .settings(
     common ++ Seq(
       name := "natchez-extras-core",
-      publish / skip := true
     )
   )
 


### PR DESCRIPTION
The core package contains some code that might be used by the consumers of this library so it should be published. I am making this change on main so that we can release it quickly for the `v6.x` line, then it can be reintegrated into the `scala-3` branch. 

Issue: #84