### PR TITLE
Aggregate core project in root

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -276,6 +276,7 @@ lazy val root = (project in file("."))
     )
   )
   .aggregate(
+    core,
     metricsCommon,
     datadogMetrics,
     datadogMilestone,


### PR DESCRIPTION
Re #84: The HEAD of this branch is tagged as `6.2.1-RC1`, the `natchez-extras-core` package is now available in maven:

<img width="632" alt="Screenshot 2022-07-04 at 12 02 47" src="https://user-images.githubusercontent.com/1415312/177141999-23309a3b-fb4a-4b93-9de7-c46c70bb50ae.png">

