### PR TITLE
Set the Datadog span's error flag, when its meta has an error message

### DIFF
--- a/natchez-extras-datadog/src/test/scala/com/ovoenergy/natchez/extras/datadog/DatadogTest.scala
+++ b/natchez-extras-datadog/src/test/scala/com/ovoenergy/natchez/extras/datadog/DatadogTest.scala
@@ -143,4 +143,23 @@ class DatadogTest extends CatsEffectSuite {
       )
     }
   }
+
+  test("Sets the error flag when the span's meta contains an error") {
+    List("error.message", "error.msg").traverse { errorMessageKey =>
+      val spans =
+        for {
+          res <- run(
+            _.root("service:resource").use { root =>
+              root.put(errorMessageKey -> "Some error")
+            }
+          )
+          spans <- res.flatTraverse(_.as[List[List[SubmittableSpan]]]).map(_.flatten)
+        } yield spans
+
+      assertIO(
+        obtained = spans.map(_.head.error),
+        returns = Some(1)
+      )
+    }
+  }
 }


### PR DESCRIPTION
This PR fixes an unexpected behaviour: when error information was manually added to the span tags, the error was displayed in the trace details, but the span itself wasn't flagged as erroneous. 