### PR TITLE
Update TracedLogger to use SelfAwareStructuredLogger trait

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -62,7 +62,7 @@ lazy val metricsCommon = projectMatrix
   .enablePlugins(GitVersioning)
   .settings(common :+ (name := "natchez-extras-metrics"))
 
-val log4catsVersion = "2.2.0"
+val log4catsVersion = "2.6.0"
 val natchezVersion = "0.1.6"
 val http4sMilestoneVersion = "1.0.0-M38"
 val http4sStableVersion = "0.23.14"


### PR DESCRIPTION
This is the most specific log4cats logger trait, which is what is used by the new LoggerFactory machinery. Without this it is very awkward to use TracedLogger with LoggerFactory