### PR TITLE
Make 'removeNumericPathSegments' method substitutable

### DIFF
--- a/natchez-extras-http4s/src/main/scala/com/ovoenergy/natchez/extras/http4s/client/TracedClient.scala
+++ b/natchez-extras-http4s/src/main/scala/com/ovoenergy/natchez/extras/http4s/client/TracedClient.scala
@@ -8,6 +8,7 @@ import com.ovoenergy.natchez.extras.http4s.Configuration
 import com.ovoenergy.natchez.extras.http4s.server.TraceMiddleware.removeNumericPathSegments
 import natchez.{Span, Trace}
 import org.http4s.Header.ToRaw.keyValuesToRaw
+import org.http4s.Uri
 import org.http4s.client.Client
 
 trait TracedClient[F[_]] {
@@ -24,7 +25,11 @@ object TracedClient {
   private def trace[F[_]]: F ~> Traced[F, *] =
     Kleisli.liftK
 
-  def apply[F[_]: Sync](client: Client[F], config: Configuration[F]): TracedClient[Traced[F, *]] =
+  def apply[F[_]: Sync](
+    client: Client[F],
+    config: Configuration[F],
+    removeNumericPathSegments: Uri => String = removeNumericPathSegments
+  ): TracedClient[Traced[F, *]] =
     name =>
       Client[Traced[F, *]] { req =>
         Resource(

--- a/natchez-extras-http4s/src/main/scala/com/ovoenergy/natchez/extras/http4s/client/TracedClient.scala
+++ b/natchez-extras-http4s/src/main/scala/com/ovoenergy/natchez/extras/http4s/client/TracedClient.scala
@@ -28,12 +28,12 @@ object TracedClient {
   def apply[F[_]: Sync](
     client: Client[F],
     config: Configuration[F],
-    removeNumericPathSegments: Uri => String = removeNumericPathSegments
+    redactSensitiveData: Uri => String = removeNumericPathSegments
   ): TracedClient[Traced[F, *]] =
     name =>
       Client[Traced[F, *]] { req =>
         Resource(
-          Trace[Traced[F, *]].span(s"$name:http.request:${removeNumericPathSegments(req.uri)}") {
+          Trace[Traced[F, *]].span(s"$name:http.request:${redactSensitiveData(req.uri)}") {
             for {
               span    <- Kleisli.ask[F, Span[F]]
               headers <- trace(span.kernel.map(_.toHeaders.toSeq))

--- a/natchez-extras-http4s/src/main/scala/com/ovoenergy/natchez/extras/http4s/server/TraceMiddleware.scala
+++ b/natchez-extras-http4s/src/main/scala/com/ovoenergy/natchez/extras/http4s/server/TraceMiddleware.scala
@@ -31,10 +31,10 @@ object TraceMiddleware {
     configuration: Configuration[F]
   )(
     service: HttpApp[Kleisli[F, Span[F], *]],
-    removeNumericPathSegments: Uri => String = removeNumericPathSegments
+    redactSensitiveData: Uri => String = removeNumericPathSegments
   )(implicit F: Sync[F]): HttpApp[F] =
     Kleisli { r =>
-      val spanName = s"http.request:${removeNumericPathSegments(r.uri)}"
+      val spanName = s"http.request:${redactSensitiveData(r.uri)}"
       val kernel = Kernel(r.headers.headers.map(h => h.name.toString -> h.value).toMap)
       val traceRequest = r.mapK(Kleisli.liftK[F, Span[F]])
 

--- a/natchez-extras-http4s/src/main/scala/com/ovoenergy/natchez/extras/http4s/server/TraceMiddleware.scala
+++ b/natchez-extras-http4s/src/main/scala/com/ovoenergy/natchez/extras/http4s/server/TraceMiddleware.scala
@@ -8,6 +8,7 @@ import org.http4s._
 import cats.syntax.flatMap._
 import cats.syntax.functor._
 import com.ovoenergy.natchez.extras.http4s.Configuration
+import org.http4s.Uri
 
 object TraceMiddleware {
 
@@ -29,7 +30,8 @@ object TraceMiddleware {
     entryPoint: EntryPoint[F],
     configuration: Configuration[F]
   )(
-    service: HttpApp[Kleisli[F, Span[F], *]]
+    service: HttpApp[Kleisli[F, Span[F], *]],
+    removeNumericPathSegments: Uri => String = removeNumericPathSegments
   )(implicit F: Sync[F]): HttpApp[F] =
     Kleisli { r =>
       val spanName = s"http.request:${removeNumericPathSegments(r.uri)}"


### PR DESCRIPTION
- optionally override the default 'removeNumericPathSegments' functionality by providing a function that does the redaction.
- `natchez-extras` should fall back to the current implementation when the function is not provided to keep backward compatibility