### PR TITLE
fix: add traces to updates with generared keys

### DIFF
--- a/natchez-extras-doobie/src/main/scala/com/ovoenergy/natchez/extras/doobie/TracedStatement.scala
+++ b/natchez-extras-doobie/src/main/scala/com/ovoenergy/natchez/extras/doobie/TracedStatement.scala
@@ -14,7 +14,8 @@ import scala.annotation.nowarn
 @nowarn
 private[doobie] case class TracedStatement(
   p: PreparedStatement,
-  queryString: String
+  queryString: String,
+  c: Any*
 ) extends PreparedStatement {
   def executeQuery(): ResultSet = p.executeQuery()
 

--- a/natchez-extras-doobie/src/main/scala/com/ovoenergy/natchez/extras/doobie/TracedTransactor.scala
+++ b/natchez-extras-doobie/src/main/scala/com/ovoenergy/natchez/extras/doobie/TracedTransactor.scala
@@ -71,7 +71,7 @@ object TracedTransactor {
 
           def runTraced[A](f: TracedOp[A]): TracedOp[A] =
             Kleisli {
-              case TracedStatement(p, sql) =>
+              case TracedStatement(p, sql, _*) =>
                 Trace[F].span(config.fullyQualifiedSpanName(formatQuery(extractQueryNameOrSql(sql))))(
                   Trace[F].put("span.type" -> "db") >> f(p)
                 )
@@ -93,12 +93,24 @@ object TracedTransactor {
 
           override val executeQuery: TracedOp[ResultSet] =
             runTraced(super.executeQuery)
+
         }
 
       override lazy val ConnectionInterpreter: ConnectionInterpreter =
         new ConnectionInterpreter {
           override def prepareStatement(a: String): Kleisli[F, Connection, PreparedStatement] =
             super.prepareStatement(a).map(TracedStatement(_, a): PreparedStatement)
+          override def prepareStatement( a: String, b: Array[String]): Kleisli[F, Connection, PreparedStatement] =
+            super.prepareStatement(a, b).map(TracedStatement(_, a, b): PreparedStatement)
+          override def prepareStatement(a: String, b: Array[Int]): Kleisli[F, Connection, PreparedStatement] =
+            super.prepareStatement(a, b).map(TracedStatement(_, a, b): PreparedStatement)
+          override def prepareStatement(a: String, b: Int) =
+            super.prepareStatement(a, b).map(TracedStatement(_, a, b): PreparedStatement)
+          override def prepareStatement(a: String, b: Int, c: Int) =
+            super.prepareStatement(a, b, c).map(TracedStatement(_, a, b, c): PreparedStatement)
+          override def prepareStatement(a: String, b: Int, c: Int, d: Int) =
+            super.prepareStatement(a, b, c, d).map(TracedStatement(_, a, b, c, d): PreparedStatement)
+
           override def getTypeMap: Nothing =
             super.getTypeMap.asInstanceOf // See: https://github.com/tpolecat/doobie/blob/v1.0.0-RC4/modules/core/src/test/scala/doobie/util/StrategySuite.scala#L47
         }

--- a/natchez-extras-doobie/src/test/scala/com/ovoenergy/natchez/extras/doobie/TracedTransactorTest.scala
+++ b/natchez-extras-doobie/src/test/scala/com/ovoenergy/natchez/extras/doobie/TracedTransactorTest.scala
@@ -65,7 +65,8 @@ class TracedTransactorTest extends CatsEffectSuite {
 
   database.test("Trace updates") { db =>
     val create = sql"CREATE TABLE a (id INT, name VARCHAR)".update.run
-    val insert = sql"INSERT INTO a VALUES (${2: Int}, ${"abc": String})".update.run
+    val insert =
+      sql"INSERT INTO a VALUES (${2: Int}, ${"abc": String})".update.withUniqueGeneratedKeys[String]("name")
     assertIO(
       run((create >> insert).transact(db)).map(_.last),
       SpanData("test-db:db.execute:INSERT INTO a VALUES (?, ?)", Map("span.type" -> "db"))


### PR DESCRIPTION
I was having trouble tracing `updates` using `withUniqueGeneratedKeys`, these changes appear to have solved the problem so far.